### PR TITLE
refactor: replace verbose code in manager_write_with_some_bad_fields_ko

### DIFF
--- a/src/main/java/school/hei/haapi/model/validator/UpdateFeeValidator.java
+++ b/src/main/java/school/hei/haapi/model/validator/UpdateFeeValidator.java
@@ -55,14 +55,14 @@ public class UpdateFeeValidator implements Consumer<Fee> {
     } else {
       Optional<Fee> optionalFee = feeRepository.findById(fee.getId());
       if (optionalFee.isEmpty()) {
-        violationMessages.add("Fee with id " + fee.getId() + "does not exist");
+        violationMessages.add("Fee with id " + fee.getId() + " does not exist");
       } else {
         Fee originalFee = optionalFee.get();
         if (!fee.getTotalAmount().equals(originalFee.getTotalAmount())) {
-          violationMessages.add("Can't modify total amount");
+          violationMessages.add("Can't modify totalAmount");
         }
         if (!fee.getCreationDatetime().equals(originalFee.getCreationDatetime())) {
-          violationMessages.add("Can't modify CreationDatetime");
+          violationMessages.add("Can't modify creationDatetime");
         }
         if (!fee.getStudent().getId().equals(originalFee.getStudent().getId())) {
           violationMessages.add("Can't modify student");

--- a/src/test/java/school/hei/haapi/integration/FeeIT.java
+++ b/src/test/java/school/hei/haapi/integration/FeeIT.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static school.hei.haapi.endpoint.rest.model.FeeStatusEnum.LATE;
 import static school.hei.haapi.endpoint.rest.model.FeeStatusEnum.PAID;
@@ -51,7 +50,6 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.HttpStatus;
@@ -332,11 +330,6 @@ class FeeIT extends FacadeITMockedThirdParties {
         () -> api.createStudentFees(STUDENT1_ID, List.of()));
   }
 
-  private void assertApiException(Executable function, String expectedMessagePart) {
-    ApiException exception = assertThrows(ApiException.class, function);
-    assertTrue(exception.getMessage().contains(expectedMessagePart));
-  }
-
   @Test
   void manager_write_with_some_bad_fields_ko() throws ApiException {
     ApiClient manager1Client = anApiClient(MANAGER1_TOKEN);
@@ -344,36 +337,37 @@ class FeeIT extends FacadeITMockedThirdParties {
     String wrongId = "some-wrong-id";
     List<Fee> expected = api.getStudentFees(STUDENT1_ID, 1, 5, null);
 
-    assertApiException(
-        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(null))),
-        "Total amount is mandatory");
-    assertApiException(
-        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(-1))),
-        "Total amount must be positive");
-    assertApiException(
-        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().dueDatetime(null))),
-        "Due datetime is mandatory");
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Total amount is mandatory\"}",
+        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(null))));
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Total amount must be positive\"}",
+        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(-1))));
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Due datetime is mandatory\"}",
+        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().dueDatetime(null))));
 
-    assertApiException(
-        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(null))), "Id is mandatory");
-    assertApiException(
-        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().type(HARDWARE))),
-        "Can't modify Type");
-    assertApiException(
-        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().remainingAmount(10))),
-        "Can't modify remainingAmount");
-    assertApiException(
-        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().totalAmount(10))),
-        "Can't modify total amount");
-    assertApiException(
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Id is mandatory\"}",
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(null))));
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify Type\"}",
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().type(HARDWARE))));
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify remainingAmount\"}",
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().remainingAmount(10))));
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify total amount\"}",
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().totalAmount(10))));
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify CreationDatetime\"}",
         () ->
             api.updateStudentFees(
                 STUDENT1_ID,
-                List.of(fee1().creationDatetime(Instant.parse("2021-11-09T10:10:10.00Z")))),
-        "Can't modify CreationDatetime");
-    assertApiException(
-        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(wrongId))),
-        "Fee with id " + wrongId + "does not exist");
+                List.of(fee1().creationDatetime(Instant.parse("2021-11-09T10:10:10.00Z")))));
+    TestUtils.assertThrowsApiException(
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Fee with id " + wrongId + "does not exist\"}",
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(wrongId))));
 
     List<Fee> actual = api.getStudentFees(STUDENT1_ID, 1, 5, null);
     assertEquals(expected.size(), actual.size());

--- a/src/test/java/school/hei/haapi/integration/FeeIT.java
+++ b/src/test/java/school/hei/haapi/integration/FeeIT.java
@@ -337,35 +337,35 @@ class FeeIT extends FacadeITMockedThirdParties {
     String wrongId = "some-wrong-id";
     List<Fee> expected = api.getStudentFees(STUDENT1_ID, 1, 5, null);
 
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Total amount is mandatory\"}",
         () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(null))));
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Total amount must be positive\"}",
         () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(-1))));
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Due datetime is mandatory\"}",
         () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().dueDatetime(null))));
 
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Id is mandatory\"}",
         () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(null))));
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify Type\"}",
         () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().type(HARDWARE))));
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify remainingAmount\"}",
         () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().remainingAmount(10))));
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify totalAmount\"}",
         () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().totalAmount(10))));
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify creationDatetime\"}",
         () ->
             api.updateStudentFees(
                 STUDENT1_ID,
                 List.of(fee1().creationDatetime(Instant.parse("2021-11-09T10:10:10.00Z")))));
-    TestUtils.assertThrowsApiException(
+    assertThrowsApiException(
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Fee with id " + wrongId + " does not exist\"}",
         () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(wrongId))));
 

--- a/src/test/java/school/hei/haapi/integration/FeeIT.java
+++ b/src/test/java/school/hei/haapi/integration/FeeIT.java
@@ -51,6 +51,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.HttpStatus;
@@ -331,76 +332,41 @@ class FeeIT extends FacadeITMockedThirdParties {
         () -> api.createStudentFees(STUDENT1_ID, List.of()));
   }
 
+  private void assertApiException(Executable function, String expectedMessagePart) {
+    ApiException exception = assertThrows(ApiException.class, function);
+    assertTrue(exception.getMessage().contains(expectedMessagePart));
+  }
+
   @Test
   void manager_write_with_some_bad_fields_ko() throws ApiException {
     ApiClient manager1Client = anApiClient(MANAGER1_TOKEN);
     PayingApi api = new PayingApi(manager1Client);
-    CreateFee toCreate1 = creatableFee1().totalAmount(null);
-    CreateFee toCreate2 = creatableFee1().totalAmount(-1);
-    CreateFee toCreate3 = creatableFee1().dueDatetime(null);
-    String wrongId = "wrong id";
+    String wrongId = "some-wrong-id";
     List<Fee> expected = api.getStudentFees(STUDENT1_ID, 1, 5, null);
 
-    ApiException exception1 =
-        assertThrows(
-            ApiException.class, () -> api.createStudentFees(STUDENT1_ID, List.of(toCreate1)));
-    ApiException exception2 =
-        assertThrows(
-            ApiException.class, () -> api.createStudentFees(STUDENT1_ID, List.of(toCreate2)));
-    ApiException exception3 =
-        assertThrows(
-            ApiException.class, () -> api.createStudentFees(STUDENT1_ID, List.of(toCreate3)));
-    ApiException exception4 =
-        assertThrows(
-            ApiException.class, () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(null))));
-    ApiException exception6 =
-        assertThrows(
-            ApiException.class,
-            () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().type(HARDWARE))));
-    ApiException exception7 =
-        assertThrows(
-            ApiException.class,
-            () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().remainingAmount(10))));
-    ApiException exception9 =
-        assertThrows(
-            ApiException.class,
-            () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().totalAmount(10))));
-    ApiException exception10 =
-        assertThrows(
-            ApiException.class,
-            () ->
-                api.updateStudentFees(
-                    STUDENT1_ID,
-                    List.of(fee1().creationDatetime(Instant.parse("2021-11-09T10:10:10.00Z")))));
-    ApiException exception11 =
-        assertThrows(
-            ApiException.class,
-            () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(wrongId))));
+    assertApiException(() -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(null))),
+            "Total amount is mandatory");
+    assertApiException(() -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(-1))),
+            "Total amount must be positive");
+    assertApiException(() -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().dueDatetime(null))),
+            "Due datetime is mandatory");
 
-    String exceptionMessage1 = exception1.getMessage();
-    String exceptionMessage2 = exception2.getMessage();
-    String exceptionMessage3 = exception3.getMessage();
-    String exceptionMessage4 = exception4.getMessage();
-    String exceptionMessage6 = exception6.getMessage();
-    String exceptionMessage7 = exception7.getMessage();
-    String exceptionMessage9 = exception9.getMessage();
-    String exceptionMessage10 = exception10.getMessage();
-    String exceptionMessage11 = exception11.getMessage();
+    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(null))),
+            "Id is mandatory");
+    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().type(HARDWARE))),
+            "Can't modify Type");
+    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().remainingAmount(10))),
+            "Can't modify remainingAmount");
+    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().totalAmount(10))),
+            "Can't modify total amount");
+    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().creationDatetime(
+                    Instant.parse("2021-11-09T10:10:10.00Z")))),
+            "Can't modify CreationDatetime");
+    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(wrongId))),
+            "Fee with id "+ wrongId +"does not exist");
 
     List<Fee> actual = api.getStudentFees(STUDENT1_ID, 1, 5, null);
     assertEquals(expected.size(), actual.size());
-
-    assertTrue(expected.containsAll(actual));
-    assertTrue(exceptionMessage1.contains("Total amount is mandatory"));
-    assertTrue(exceptionMessage2.contains("Total amount must be positive"));
-    assertTrue(exceptionMessage3.contains("Due datetime is mandatory"));
-
-    assertTrue(exceptionMessage4.contains("Id is mandatory"));
-    assertTrue(exceptionMessage6.contains("Can't modify Type"));
-    assertTrue(exceptionMessage7.contains("Can't modify remainingAmount"));
-    assertTrue(exceptionMessage9.contains("Can't modify total amount"));
-    assertTrue(exceptionMessage10.contains("Can't modify CreationDatetime"));
-    assertTrue(exceptionMessage11.contains("Fee with id " + wrongId + "does not exist"));
   }
 
   @Test

--- a/src/test/java/school/hei/haapi/integration/FeeIT.java
+++ b/src/test/java/school/hei/haapi/integration/FeeIT.java
@@ -344,26 +344,36 @@ class FeeIT extends FacadeITMockedThirdParties {
     String wrongId = "some-wrong-id";
     List<Fee> expected = api.getStudentFees(STUDENT1_ID, 1, 5, null);
 
-    assertApiException(() -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(null))),
-            "Total amount is mandatory");
-    assertApiException(() -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(-1))),
-            "Total amount must be positive");
-    assertApiException(() -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().dueDatetime(null))),
-            "Due datetime is mandatory");
+    assertApiException(
+        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(null))),
+        "Total amount is mandatory");
+    assertApiException(
+        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().totalAmount(-1))),
+        "Total amount must be positive");
+    assertApiException(
+        () -> api.createStudentFees(STUDENT1_ID, List.of(creatableFee1().dueDatetime(null))),
+        "Due datetime is mandatory");
 
-    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(null))),
-            "Id is mandatory");
-    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().type(HARDWARE))),
-            "Can't modify Type");
-    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().remainingAmount(10))),
-            "Can't modify remainingAmount");
-    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().totalAmount(10))),
-            "Can't modify total amount");
-    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().creationDatetime(
-                    Instant.parse("2021-11-09T10:10:10.00Z")))),
-            "Can't modify CreationDatetime");
-    assertApiException(() -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(wrongId))),
-            "Fee with id "+ wrongId +"does not exist");
+    assertApiException(
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(null))), "Id is mandatory");
+    assertApiException(
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().type(HARDWARE))),
+        "Can't modify Type");
+    assertApiException(
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().remainingAmount(10))),
+        "Can't modify remainingAmount");
+    assertApiException(
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().totalAmount(10))),
+        "Can't modify total amount");
+    assertApiException(
+        () ->
+            api.updateStudentFees(
+                STUDENT1_ID,
+                List.of(fee1().creationDatetime(Instant.parse("2021-11-09T10:10:10.00Z")))),
+        "Can't modify CreationDatetime");
+    assertApiException(
+        () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(wrongId))),
+        "Fee with id " + wrongId + "does not exist");
 
     List<Fee> actual = api.getStudentFees(STUDENT1_ID, 1, 5, null);
     assertEquals(expected.size(), actual.size());

--- a/src/test/java/school/hei/haapi/integration/FeeIT.java
+++ b/src/test/java/school/hei/haapi/integration/FeeIT.java
@@ -357,16 +357,16 @@ class FeeIT extends FacadeITMockedThirdParties {
         "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify remainingAmount\"}",
         () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().remainingAmount(10))));
     TestUtils.assertThrowsApiException(
-        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify total amount\"}",
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify totalAmount\"}",
         () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().totalAmount(10))));
     TestUtils.assertThrowsApiException(
-        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify CreationDatetime\"}",
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Can't modify creationDatetime\"}",
         () ->
             api.updateStudentFees(
                 STUDENT1_ID,
                 List.of(fee1().creationDatetime(Instant.parse("2021-11-09T10:10:10.00Z")))));
     TestUtils.assertThrowsApiException(
-        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Fee with id " + wrongId + "does not exist\"}",
+        "{\"type\":\"400 BAD_REQUEST\",\"message\":\"Fee with id " + wrongId + " does not exist\"}",
         () -> api.updateStudentFees(STUDENT1_ID, List.of(fee1().id(wrongId))));
 
     List<Fee> actual = api.getStudentFees(STUDENT1_ID, 1, 5, null);


### PR DESCRIPTION
refactored manager_write_with_some_bad_fields_ko test which was too long and had many redundancies. I simply used a helperFunction `assertApiException` which does both `assertThrows` and `assertEquals` on the expected error message. 