### PR TITLE
feat: add getStudentByIdAndMonitorId feature with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
 
     env:
       AWS_REGION: eu-west-3
+      JAVA_TOOL_OPTIONS: "-Dlombok.debug=true"
 
     steps:
       - uses: actions/checkout@v4.1.6
@@ -31,7 +32,7 @@ jobs:
           distribution: 'corretto'
       - run: chmod +x gradlew
       - run: chmod +x .shell/publish_gen_to_maven_local.sh
-      - run: ./gradlew test
+      - run: ./gradlew test --stacktrace --info
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
           distribution: 'corretto'
       - run: chmod +x gradlew
       - run: chmod +x .shell/publish_gen_to_maven_local.sh
+
+      - name: Compile only (debug)
+        run: ./gradlew compileJava --debug
+
       - run: ./gradlew test --stacktrace --info
 
       - name: Cache SonarCloud packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
       - run: chmod +x gradlew
       - run: chmod +x .shell/publish_gen_to_maven_local.sh
 
-      - name: Compile only (debug)
-        run: ./gradlew compileJava --debug
+      - name: Compile only with Lombok debug
+        run: ./gradlew compileJava --stacktrace -Plombok.debug=true
 
-      - run: ./gradlew test --stacktrace --info
+      - run: ./gradlew test
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v4.2.2

--- a/doc/api.yml
+++ b/doc/api.yml
@@ -4468,6 +4468,40 @@ paths:
           $ref: '#/components/responses/429'
         '500':
           $ref: '#/components/responses/500'
+  /monitors/{monitor_id}/students/{student_id}:
+    get: 
+      tags:
+        - Monitoring 
+      summary: Get a student using its monitor id.
+      parameters: 
+        - name: monitor_id
+          in: path
+          required: true
+          schema: 
+            type: string
+        - name: student_id
+          in: path
+          required: true
+          schema:
+            type: string
+      operationId: getLinkedStudentByIdAndMonitorId
+      responses:
+        '200':
+          description: A student monitored by the monitor_id with the given student_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Student"
+        '400': 
+          $ref: '#/components/responses/400'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '429':
+          $ref: '#/components/responses/429'
+        '500': 
+          $ref: '#/components/responses/500'
   /events:
     get:
       tags:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=1.107.0
+lombok.debug=true

--- a/src/main/java/school/hei/haapi/endpoint/event/model/AdvancedFeeStatsComputationTriggered.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/AdvancedFeeStatsComputationTriggered.java
@@ -16,7 +16,7 @@ import school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsCountT
 import school.hei.haapi.service.utils.DateUtils;
 import school.hei.haapi.service.utils.DateUtils.TimeRange;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @ToString
 @Getter
 public class AdvancedFeeStatsComputationTriggered extends PojaEvent {

--- a/src/main/java/school/hei/haapi/endpoint/event/model/AnnouncementEmailSendRequested.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/AnnouncementEmailSendRequested.java
@@ -8,7 +8,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.endpoint.rest.model.Scope;
 import school.hei.haapi.model.User;
@@ -18,7 +20,8 @@ import school.hei.haapi.model.User;
 @EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
-@Data
+@Getter
+@Setter
 public class AnnouncementEmailSendRequested extends PojaEvent {
   @JsonProperty("id")
   private String id;

--- a/src/main/java/school/hei/haapi/endpoint/event/model/AnnouncementEmailSendRequested.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/AnnouncementEmailSendRequested.java
@@ -15,7 +15,7 @@ import school.hei.haapi.model.User;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @Data

--- a/src/main/java/school/hei/haapi/endpoint/event/model/AnnouncementSendInit.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/AnnouncementSendInit.java
@@ -9,10 +9,11 @@ import school.hei.haapi.model.notEntity.Group;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
-@Data
+@Getter
+@Setter
 public class AnnouncementSendInit extends PojaEvent {
   @JsonProperty("id")
   private String id;

--- a/src/main/java/school/hei/haapi/endpoint/event/model/CheckAttendanceTriggered.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/CheckAttendanceTriggered.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/CheckMobilePaymentTransactionTriggered.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/CheckMobilePaymentTransactionTriggered.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/CheckSuspendedStudentsStatus.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/CheckSuspendedStudentsStatus.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/DurablyFallibleUuidCreated1.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/DurablyFallibleUuidCreated1.java
@@ -7,7 +7,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.PojaGenerated;
 
@@ -16,7 +18,8 @@ import school.hei.haapi.PojaGenerated;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Data
+@Getter
+@Setter
 @EqualsAndHashCode(callSuper = false)
 @ToString
 public class DurablyFallibleUuidCreated1 extends PojaEvent {

--- a/src/main/java/school/hei/haapi/endpoint/event/model/DurablyFallibleUuidCreated2.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/DurablyFallibleUuidCreated2.java
@@ -8,7 +8,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.PojaGenerated;
 import school.hei.haapi.endpoint.event.EventStack;
@@ -18,7 +20,8 @@ import school.hei.haapi.endpoint.event.EventStack;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Data
+@Getter
+@Setter
 @EqualsAndHashCode(callSuper = false)
 @ToString
 public class DurablyFallibleUuidCreated2 extends PojaEvent {

--- a/src/main/java/school/hei/haapi/endpoint/event/model/FetchMobileTransactionTriggered.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/FetchMobileTransactionTriggered.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/HandleReceiptGenerationRequest.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/HandleReceiptGenerationRequest.java
@@ -5,15 +5,17 @@ import java.time.Duration;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.model.dto.PaymentDto;
 
 @AllArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @ToString
-@Data
+@Getter
+@Setter
 @Builder
 public class HandleReceiptGenerationRequest extends PojaEvent {
 

--- a/src/main/java/school/hei/haapi/endpoint/event/model/LateFeeVerified.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/LateFeeVerified.java
@@ -5,19 +5,21 @@ import java.time.Duration;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.endpoint.rest.model.FeeTypeEnum;
 import school.hei.haapi.model.User;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
-@Data
+@Getter
+@Setter
 public class LateFeeVerified extends PojaEvent {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/school/hei/haapi/endpoint/event/model/MissedEventEmail.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/MissedEventEmail.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import school.hei.haapi.model.EventParticipant;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/PaidFeeByMpbsFailedNotificationBody.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/PaidFeeByMpbsFailedNotificationBody.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.model.Fee;
 import school.hei.haapi.model.Payment;
@@ -14,9 +15,10 @@ import school.hei.haapi.model.User;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
-@Data
+@Getter
+@Setter
 @ToString
 public class PaidFeeByMpbsFailedNotificationBody extends PojaEvent {
   @JsonProperty("mpbs_author")

--- a/src/main/java/school/hei/haapi/endpoint/event/model/PaidFeeByMpbsNotificationBody.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/PaidFeeByMpbsNotificationBody.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.model.Fee;
 import school.hei.haapi.model.Payment;
@@ -14,9 +15,10 @@ import school.hei.haapi.model.User;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
-@Data
+@Getter
+@Setter
 @ToString
 public class PaidFeeByMpbsNotificationBody extends PojaEvent {
   @JsonProperty("mpbs_author")

--- a/src/main/java/school/hei/haapi/endpoint/event/model/SendLateFeesEmailTriggered.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/SendLateFeesEmailTriggered.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/SendLetterEmail.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/SendLetterEmail.java
@@ -6,7 +6,7 @@ import lombok.*;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @Getter

--- a/src/main/java/school/hei/haapi/endpoint/event/model/SendRequestReceiptGeneration.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/SendRequestReceiptGeneration.java
@@ -13,7 +13,7 @@ import school.hei.haapi.model.dto.PaymentDto;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @Getter

--- a/src/main/java/school/hei/haapi/endpoint/event/model/SendUnpaidFeesReminderTriggered.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/SendUnpaidFeesReminderTriggered.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/StudentsWithOverdueFeesReminder.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/StudentsWithOverdueFeesReminder.java
@@ -8,7 +8,7 @@ import school.hei.haapi.model.Fee;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @Getter

--- a/src/main/java/school/hei/haapi/endpoint/event/model/SuspendStudentsWithOverdueFees.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/SuspendStudentsWithOverdueFees.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/SuspensionEndedEmailBody.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/SuspensionEndedEmailBody.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.model.Fee;
 import school.hei.haapi.model.Payment;
@@ -14,9 +15,10 @@ import school.hei.haapi.model.User;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
-@Data
+@Getter
+@Setter
 @ToString
 public class SuspensionEndedEmailBody extends PojaEvent {
   @JsonProperty("mpbs_author")

--- a/src/main/java/school/hei/haapi/endpoint/event/model/UnpaidFeesReminder.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/UnpaidFeesReminder.java
@@ -5,16 +5,18 @@ import java.time.Duration;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.model.User;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor
-@Data
+@Getter
+@Setter
 public class UnpaidFeesReminder extends PojaEvent {
   @JsonProperty("concerned_student")
   UnpaidFeesUser user;

--- a/src/main/java/school/hei/haapi/endpoint/event/model/UpdateFeesStatusToLateTriggered.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/UpdateFeesStatusToLateTriggered.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/endpoint/event/model/UpdateLetterEmail.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/UpdateLetterEmail.java
@@ -7,7 +7,7 @@ import school.hei.haapi.endpoint.rest.model.LetterStatus;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @Builder
 @ToString
 @Getter

--- a/src/main/java/school/hei/haapi/endpoint/event/model/UuidCreated.java
+++ b/src/main/java/school/hei/haapi/endpoint/event/model/UuidCreated.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import school.hei.haapi.PojaGenerated;
 
@@ -15,7 +16,8 @@ import school.hei.haapi.PojaGenerated;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@Data
+@Getter
+@Setter
 @EqualsAndHashCode(callSuper = false)
 @ToString
 public class UuidCreated extends PojaEvent {

--- a/src/main/java/school/hei/haapi/endpoint/rest/controller/MonitoringStudentController.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/controller/MonitoringStudentController.java
@@ -1,7 +1,5 @@
 package school.hei.haapi.endpoint.rest.controller;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
-
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,7 +28,7 @@ public class MonitoringStudentController {
         .linkMonitorFollowingStudents(id, request.getStudentsIds())
         .stream()
         .map(userMapper::toRestStudent)
-        .collect(toUnmodifiableList());
+        .toList();
   }
 
   @GetMapping(value = "/monitors/{id}/students")
@@ -40,6 +38,14 @@ public class MonitoringStudentController {
       @RequestParam(name = "page_size") BoundedPageSize pageSize) {
     return monitoringStudentService.getStudentsByMonitorId(id, page, pageSize).stream()
         .map(userMapper::toRestStudent)
-        .collect(toUnmodifiableList());
+        .toList();
+  }
+
+  @GetMapping("/monitors/{monitor_id}/students/{student_id}")
+  public Student getLinkedStudentByIdAndMonitorId(
+      @PathVariable(name = "monitor_id") String monitorId,
+      @PathVariable(name = "student_id") String studentId) {
+    return userMapper.toRestStudent(
+        monitoringStudentService.getStudentByIdAndMonitorId(studentId, monitorId));
   }
 }

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
@@ -147,6 +147,7 @@ public class SecurityConf {
                     antMatcher(PUT, "/monitors"),
                     antMatcher(PUT, "/monitors/*/students"),
                     antMatcher(GET, "/monitors/*/students"),
+                    antMatcher(GET, "/monitors/*/students/*"),
                     antMatcher(GET, "/teachers"),
                     antMatcher(GET, "/teachers/*"),
                     antMatcher(GET, "/students/*/scholarship_certificate/raw"),
@@ -412,6 +413,12 @@ public class SecurityConf {
                     .requestMatchers(new SelfMatcher(GET, "/monitors/*/students", "monitors"))
                     .hasAnyRole(MONITOR.getRole(), ADMIN.getRole())
                     .requestMatchers(GET, "/monitors/*/students")
+                    .hasAnyRole(MANAGER.getRole(), ADMIN.getRole())
+                    .requestMatchers(
+                        new StudentMonitorMatcher(
+                            GET, "/monitors/*/students/*", "students", monitoringStudentService))
+                    .hasAnyRole(MONITOR.getRole())
+                    .requestMatchers(GET, "/monitors/*/students/*")
                     .hasAnyRole(MANAGER.getRole(), ADMIN.getRole())
                     //
                     // Fees resources

--- a/src/main/java/school/hei/haapi/model/Mpbs/MpbsVerification.java
+++ b/src/main/java/school/hei/haapi/model/Mpbs/MpbsVerification.java
@@ -23,7 +23,7 @@ import school.hei.haapi.model.User;
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @ToString(callSuper = true)
 public class MpbsVerification extends TypedMobileMoneyTransaction implements Serializable {
   private Integer amountOfFeeRemainingPayment;

--- a/src/main/java/school/hei/haapi/model/Payment.java
+++ b/src/main/java/school/hei/haapi/model/Payment.java
@@ -18,7 +18,6 @@ import java.time.Instant;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -36,7 +35,6 @@ import org.hibernate.annotations.Where;
 @NoArgsConstructor
 @SQLDelete(sql = "update \"payment\" set is_deleted = true where id = ?")
 @Where(clause = "is_deleted = false")
-@EqualsAndHashCode
 public class Payment implements Serializable {
   @Id
   @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/school/hei/haapi/model/notEntity/Group.java
+++ b/src/main/java/school/hei/haapi/model/notEntity/Group.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @AllArgsConstructor
@@ -14,7 +15,8 @@ import lombok.ToString;
 @EqualsAndHashCode
 @Builder
 @ToString
-@Data
+@Getter
+@Setter
 public class Group implements Serializable {
   @JsonProperty("id")
   private String id;

--- a/src/main/java/school/hei/haapi/model/notEntity/MpbsDTO.java
+++ b/src/main/java/school/hei/haapi/model/notEntity/MpbsDTO.java
@@ -2,9 +2,10 @@ package school.hei.haapi.model.notEntity;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @AllArgsConstructor
@@ -12,7 +13,8 @@ import lombok.ToString;
 @EqualsAndHashCode
 @Builder
 @ToString
-@Data
+@Getter
+@Setter
 public class MpbsDTO {
 
   private String reference;

--- a/src/main/java/school/hei/haapi/model/notEntity/OcsData.java
+++ b/src/main/java/school/hei/haapi/model/notEntity/OcsData.java
@@ -17,7 +17,7 @@ import lombok.ToString;
 @Builder
 @ToString
 @Getter
-@Data
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OcsData {
   @JsonProperty("ocs")

--- a/src/main/java/school/hei/haapi/service/MonitoringStudentService.java
+++ b/src/main/java/school/hei/haapi/service/MonitoringStudentService.java
@@ -1,6 +1,5 @@
 package school.hei.haapi.service;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.springframework.data.domain.Sort.Direction.ASC;
 
 import java.util.List;
@@ -17,6 +16,7 @@ import school.hei.haapi.endpoint.rest.model.CrupdateMonitor;
 import school.hei.haapi.model.BoundedPageSize;
 import school.hei.haapi.model.PageFromOne;
 import school.hei.haapi.model.User;
+import school.hei.haapi.model.exception.BadRequestException;
 import school.hei.haapi.model.exception.NotFoundException;
 import school.hei.haapi.repository.MonitoringStudentRepository;
 import school.hei.haapi.repository.UserRepository;
@@ -57,7 +57,7 @@ public class MonitoringStudentService {
           List<String> studentsIds =
               userRepository.findAllByRefIn(monitor.getStudentRefs()).stream()
                   .map(User::getId)
-                  .collect(toUnmodifiableList());
+                  .toList();
 
           linkMonitorFollowingStudents(
               userRepository
@@ -109,5 +109,18 @@ public class MonitoringStudentService {
         .latitude(monitor.getCoordinates().getLatitude())
         .highSchoolOrigin(monitor.getHighSchoolOrigin())
         .build();
+  }
+
+  public User getStudentByIdAndMonitorId(String studentId, String monitorId)
+      throws BadRequestException {
+    var optionalStudent = userRepository.findById(studentId);
+    if (optionalStudent.isEmpty() || optionalStudent.get().getRole() != User.Role.STUDENT) {
+      throw new BadRequestException("Student with id: " + studentId + " does not exist");
+    }
+    if (!monitoringStudentRepository.getAllMonitorsIdsByStudentId(studentId).contains(monitorId)) {
+      throw new BadRequestException(
+          "Monitor with id: " + monitorId + " does not have a student with id: " + studentId);
+    }
+    return optionalStudent.get();
   }
 }

--- a/src/test/java/school/hei/haapi/integration/MonitoringStudentIT.java
+++ b/src/test/java/school/hei/haapi/integration/MonitoringStudentIT.java
@@ -3,6 +3,10 @@ package school.hei.haapi.integration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static school.hei.haapi.integration.conf.TestUtils.ADMIN1_TOKEN;
+import static school.hei.haapi.integration.conf.TestUtils.AXEL_MONITOR_TOKEN;
 import static school.hei.haapi.integration.conf.TestUtils.MANAGER1_TOKEN;
 import static school.hei.haapi.integration.conf.TestUtils.MONITOR1_ID;
 import static school.hei.haapi.integration.conf.TestUtils.MONITOR2_ID;
@@ -11,6 +15,7 @@ import static school.hei.haapi.integration.conf.TestUtils.STUDENT1_TOKEN;
 import static school.hei.haapi.integration.conf.TestUtils.STUDENT2_ID;
 import static school.hei.haapi.integration.conf.TestUtils.STUDENT3_ID;
 import static school.hei.haapi.integration.conf.TestUtils.TEACHER1_TOKEN;
+import static school.hei.haapi.integration.conf.TestUtils.TOLOJANAHARY_MONITOR_TOKEN;
 import static school.hei.haapi.integration.conf.TestUtils.assertThrowsForbiddenException;
 import static school.hei.haapi.integration.conf.TestUtils.monitor1Link;
 import static school.hei.haapi.integration.conf.TestUtils.monitor2Link;
@@ -19,11 +24,19 @@ import static school.hei.haapi.integration.conf.TestUtils.setUpCognito;
 import static school.hei.haapi.integration.conf.TestUtils.setUpEventBridge;
 import static school.hei.haapi.integration.conf.TestUtils.student1;
 import static school.hei.haapi.integration.conf.TestUtils.student2;
+import static school.hei.haapi.integration.test_data.MonitorTestData.monitorOfAxel;
+import static school.hei.haapi.integration.test_data.MonitorTestData.monitorOfTolojanahary;
+import static school.hei.haapi.integration.test_data.StudentTestData.axel;
+import static school.hei.haapi.integration.test_data.StudentTestData.tolojanahary;
 
 import java.util.List;
+import org.casbin.casdoor.entity.CasdoorRole;
+import org.casbin.casdoor.entity.CasdoorUser;
+import org.casbin.casdoor.service.CasdoorAuthService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -32,16 +45,29 @@ import school.hei.haapi.endpoint.rest.api.PayingApi;
 import school.hei.haapi.endpoint.rest.api.UsersApi;
 import school.hei.haapi.endpoint.rest.client.ApiClient;
 import school.hei.haapi.endpoint.rest.client.ApiException;
+import school.hei.haapi.endpoint.rest.mapper.UserMapper;
 import school.hei.haapi.endpoint.rest.model.Fee;
 import school.hei.haapi.endpoint.rest.model.Student;
+import school.hei.haapi.endpoint.rest.security.casdoorAuthentication.config.CertificateLoader;
 import school.hei.haapi.integration.conf.FacadeITMockedThirdParties;
 import school.hei.haapi.integration.conf.TestUtils;
+import school.hei.haapi.model.User;
+import school.hei.haapi.repository.MonitoringStudentRepository;
+import school.hei.haapi.repository.UserRepository;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 
 @Testcontainers
 @AutoConfigureMockMvc
 public class MonitoringStudentIT extends FacadeITMockedThirdParties {
   @MockBean private EventBridgeClient eventBridgeClientMock;
+  @Autowired private UserMapper userMapper;
+  @Autowired UserRepository userRepository;
+  @Autowired MonitoringStudentRepository monitoringStudentRepository;
+
+  private User studentAxel = axel();
+  private User studentTolojanahary = tolojanahary();
+  private User monitorOfAxel = monitorOfAxel();
+  private User monitorOfTolojanahary = monitorOfTolojanahary();
 
   private ApiClient anApiClient(String token) {
     return TestUtils.anApiClient(token, localPort);
@@ -52,6 +78,20 @@ public class MonitoringStudentIT extends FacadeITMockedThirdParties {
     setUpCasdoor(casdoorAuthServiceMock, certificateLoaderMock);
     setUpCognito(cognitoComponentMock);
     setUpEventBridge(eventBridgeClientMock);
+    setUpTestData();
+  }
+
+  private void setUpTestData() {
+    studentAxel = axel();
+    studentTolojanahary = tolojanahary();
+    monitorOfAxel = monitorOfAxel();
+    monitorOfTolojanahary = monitorOfTolojanahary();
+    userRepository.saveAll(List.of(monitorOfAxel, monitorOfTolojanahary));
+    userRepository.saveAll(List.of(studentAxel, studentTolojanahary));
+    monitoringStudentRepository.saveMonitorFollowingStudents(
+        monitorOfAxel.getId(), studentAxel.getId());
+    monitoringStudentRepository.saveMonitorFollowingStudents(
+        monitorOfTolojanahary.getId(), studentTolojanahary.getId());
   }
 
   @Test
@@ -110,5 +150,73 @@ public class MonitoringStudentIT extends FacadeITMockedThirdParties {
 
   public static List<String> someStudentsRefsToLinkToAMonitor() {
     return List.of(student1().getRef(), student2().getRef());
+  }
+
+  @Test
+  void monitor_get_monitored_student_ok() throws ApiException {
+    setUpCasdoorMonitor(casdoorAuthServiceMock, certificateLoaderMock, monitorOfAxel);
+    MonitoringApi api = new MonitoringApi(anApiClient(AXEL_MONITOR_TOKEN));
+
+    var actualStudent =
+        api.getLinkedStudentByIdAndMonitorId(monitorOfAxel.getId(), studentAxel.getId());
+
+    assertEquals(userMapper.toRestStudent(studentAxel), actualStudent);
+  }
+
+  @Test
+  void monitor_get_non_monitored_students_ko() {
+    setUpCasdoorMonitor(casdoorAuthServiceMock, certificateLoaderMock, monitorOfAxel);
+    MonitoringApi api = new MonitoringApi(anApiClient(AXEL_MONITOR_TOKEN));
+
+    assertThrowsForbiddenException(
+        () ->
+            api.getLinkedStudentByIdAndMonitorId(
+                monitorOfAxel.getId(), studentTolojanahary.getId()));
+  }
+
+  @Test
+  void teacher_getStudentByIdAndMonitorId_ko() {
+    MonitoringApi api = new MonitoringApi(anApiClient(TEACHER1_TOKEN));
+
+    assertThrowsForbiddenException(
+        () -> api.getLinkedStudentByIdAndMonitorId(monitorOfAxel.getId(), studentAxel.getId()));
+  }
+
+  @Test
+  void manager_or_admin_getStudentByIdAndMonitorId_ok() throws ApiException {
+    ApiClient managerClient = anApiClient(MANAGER1_TOKEN);
+    ApiClient adminClient = anApiClient(ADMIN1_TOKEN);
+    MonitoringApi managerApi = new MonitoringApi(managerClient);
+    MonitoringApi adminApi = new MonitoringApi(adminClient);
+
+    var studentAsManager =
+        managerApi.getLinkedStudentByIdAndMonitorId(monitorOfAxel.getId(), studentAxel.getId());
+    var studentAsAdmin =
+        adminApi.getLinkedStudentByIdAndMonitorId(monitorOfAxel.getId(), studentAxel.getId());
+
+    assertEquals(userMapper.toRestStudent(studentAxel), studentAsAdmin);
+    assertEquals(userMapper.toRestStudent(studentAxel), studentAsManager);
+  }
+
+  private void setUpCasdoorMonitor(
+      CasdoorAuthService casdoorAuthService, CertificateLoader certificateLoader, User monitor) {
+    given(certificateLoader.getCertificate()).willReturn("mocked-certificate");
+    when(casdoorAuthService.parseJwtToken(AXEL_MONITOR_TOKEN))
+        .thenReturn(getCasdoorUserFromMonitor(monitor));
+    when(casdoorAuthService.parseJwtToken(TOLOJANAHARY_MONITOR_TOKEN))
+        .thenReturn(getCasdoorUserFromMonitor(monitor));
+  }
+
+  private CasdoorUser getCasdoorUserFromMonitor(User monitor) {
+    CasdoorUser user = new CasdoorUser();
+    user.setEmail(monitor.getEmail());
+    CasdoorRole casdoorRole = new CasdoorRole();
+    casdoorRole.setOwner("dummy");
+    casdoorRole.setName("student");
+    String[] roleUsers = List.of("dummy/user").toArray(new String[0]);
+    casdoorRole.setUsers(roleUsers);
+    user.setRoles(List.of(casdoorRole));
+
+    return user;
   }
 }

--- a/src/test/java/school/hei/haapi/integration/conf/TestUtils.java
+++ b/src/test/java/school/hei/haapi/integration/conf/TestUtils.java
@@ -174,6 +174,7 @@ public class TestUtils {
   public static final String TEACHER1_TOKEN = "teacher1_token";
   public static final String MONITOR1_TOKEN = "monitor1_token";
   public static final String AXEL_MONITOR_TOKEN = "axel_monitor_token";
+  public static final String TOLOJANAHARY_MONITOR_TOKEN = "tolojanahary_monitor_token";
   public static final String MONITOR2_TOKEN = "monitor2_token";
   public static final String MANAGER1_TOKEN = "manager1_token";
   public static final String STAFF_MEMBER1_TOKEN = "staff1_token";

--- a/src/test/java/school/hei/haapi/service/MonitoringStudentServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/MonitoringStudentServiceTest.java
@@ -2,6 +2,7 @@ package school.hei.haapi.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -18,11 +19,10 @@ import school.hei.haapi.model.exception.BadRequestException;
 import school.hei.haapi.repository.MonitoringStudentRepository;
 import school.hei.haapi.repository.UserRepository;
 
-@ExtendWith(MockitoExtension.class)
 public class MonitoringStudentServiceTest {
-  @Mock UserRepository userRepository;
-  @Mock MonitoringStudentRepository monitoringStudentRepository;
-  @InjectMocks MonitoringStudentService subject;
+  private final UserRepository userRepository = mock();
+  private final MonitoringStudentRepository monitoringStudentRepository = mock();
+  private final MonitoringStudentService subject = new MonitoringStudentService(userRepository, mock(), mock(), monitoringStudentRepository);
 
   @Test
   void getStudentByIdAndMonitorId_with_unexistingStudentId_ko() {

--- a/src/test/java/school/hei/haapi/service/MonitoringStudentServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/MonitoringStudentServiceTest.java
@@ -9,11 +9,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import school.hei.haapi.model.User;
 import school.hei.haapi.model.exception.BadRequestException;
 import school.hei.haapi.repository.MonitoringStudentRepository;
@@ -22,7 +18,8 @@ import school.hei.haapi.repository.UserRepository;
 public class MonitoringStudentServiceTest {
   private final UserRepository userRepository = mock();
   private final MonitoringStudentRepository monitoringStudentRepository = mock();
-  private final MonitoringStudentService subject = new MonitoringStudentService(userRepository, mock(), mock(), monitoringStudentRepository);
+  private final MonitoringStudentService subject =
+      new MonitoringStudentService(userRepository, mock(), mock(), monitoringStudentRepository);
 
   @Test
   void getStudentByIdAndMonitorId_with_unexistingStudentId_ko() {

--- a/src/test/java/school/hei/haapi/service/MonitoringStudentServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/MonitoringStudentServiceTest.java
@@ -1,0 +1,78 @@
+package school.hei.haapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import school.hei.haapi.model.User;
+import school.hei.haapi.model.exception.BadRequestException;
+import school.hei.haapi.repository.MonitoringStudentRepository;
+import school.hei.haapi.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class MonitoringStudentServiceTest {
+  @Mock UserRepository userRepository;
+  @Mock MonitoringStudentRepository monitoringStudentRepository;
+  @InjectMocks MonitoringStudentService subject;
+
+  @Test
+  void getStudentByIdAndMonitorId_with_unexistingStudentId_ko() {
+    when(userRepository.findById("non-existing-student-id")).thenReturn(Optional.empty());
+
+    assertBadRequestException(
+        "Student with id: non-existing-student-id does not exist",
+        () -> subject.getStudentByIdAndMonitorId("non-existing-student-id", "good-monitor-id"));
+  }
+
+  @Test
+  void getStudentByIdAndMonitorId_with_nonStudentId_ko() {
+    var teacherId = "some-teacher-id";
+    when(userRepository.findById(teacherId))
+        .thenReturn(
+            Optional.of(
+                User.builder()
+                    .id(teacherId)
+                    .email("teacher-email@mail.hei.school")
+                    .entranceDatetime(Instant.parse("2021-01-01T00:00:00Z"))
+                    .role(User.Role.TEACHER)
+                    .build()));
+
+    assertBadRequestException(
+        "Student with id: %s does not exist".formatted(teacherId),
+        () -> subject.getStudentByIdAndMonitorId(teacherId, "good-monitor-id"));
+  }
+
+  @Test
+  void getStudentByIdAndMonitorId_with_unlinkedMonitorAndStudent_ko() {
+    var studentId = "good-student-id";
+    var monitorId = "good-monitor-id";
+    when(userRepository.findById(studentId))
+        .thenReturn(
+            Optional.of(
+                User.builder()
+                    .id(studentId)
+                    .email("some-unique-email@gmail.com")
+                    .entranceDatetime(Instant.parse("2021-01-01T00:00:00Z"))
+                    .role(User.Role.STUDENT)
+                    .build()));
+    when(monitoringStudentRepository.getAllMonitorsIdsByStudentId(studentId)).thenReturn(List.of());
+
+    assertBadRequestException(
+        "Monitor with id: " + monitorId + " does not have a student with id: " + studentId,
+        () -> subject.getStudentByIdAndMonitorId(studentId, "good-monitor-id"));
+  }
+
+  private static void assertBadRequestException(String expectedMessage, Executable executable) {
+    var exception = assertThrows(BadRequestException.class, executable);
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+}


### PR DESCRIPTION
We needed an endpoint for monitors to check a single student that they monitor, so here we are. I added tests for the service in case : 
a. the student does not exist
b. the monitor does not actually have such student. 