### PR TITLE
chore: add tests and advancedFeeStats query for receipt type

### DIFF
--- a/src/main/java/school/hei/haapi/repository/FeeRepository.java
+++ b/src/main/java/school/hei/haapi/repository/FeeRepository.java
@@ -70,4 +70,6 @@ public interface FeeRepository extends JpaRepository<Fee, String> {
       @Param(value = "toCompare") Instant toCompare,
       @Param("studentId") String studentId,
       @Param("status") FeeStatusEnum status);
+
+  List<Fee> findAllByStatusHistoriesDatetimeBetween(Instant dayStart, Instant dayEnd);
 }

--- a/src/main/java/school/hei/haapi/repository/FeeRepository.java
+++ b/src/main/java/school/hei/haapi/repository/FeeRepository.java
@@ -71,5 +71,5 @@ public interface FeeRepository extends JpaRepository<Fee, String> {
       @Param("studentId") String studentId,
       @Param("status") FeeStatusEnum status);
 
-  List<Fee> findAllByStatusHistoriesDatetimeBetween(Instant dayStart, Instant dayEnd);
+  List<Fee> findDistinctByStatusHistoriesDatetimeBetween(Instant dayStart, Instant dayEnd);
 }

--- a/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
+++ b/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
@@ -22,7 +22,6 @@ import static school.hei.haapi.endpoint.rest.model.FeeTypeEnum.TUITION;
 import static school.hei.haapi.model.fee.PaymentType.BANK;
 import static school.hei.haapi.model.fee.PaymentType.MPBS;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsCountType.ACCOUNTING;
-import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsCountType.RECEIPT;
 
 import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
@@ -130,7 +129,8 @@ public class AdvancedFeeStatsService {
     List<Fee> allFees =
         switch (type) {
           case ACCOUNTING -> feeRepository.findAllByDueDatetimeBetween(dayStart, dayEnd);
-          case RECEIPT -> feeRepository.findAllByStatusHistoriesDatetimeBetween(dayStart, dayEnd);
+          case RECEIPT ->
+              feeRepository.findDistinctByStatusHistoriesDatetimeBetween(dayStart, dayEnd);
         };
 
     Collection<AdvancedFeeStats> stats =

--- a/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
+++ b/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
@@ -127,7 +127,11 @@ public class AdvancedFeeStatsService {
     Instant dayStart = fromDate.atStartOfDay().toInstant(UTC);
     Instant dayEnd = toDate.atTime(23, 59, 59).toInstant(UTC);
 
-    List<Fee> allFees = feeRepository.findAllByDueDatetimeBetween(dayStart, dayEnd);
+    List<Fee> allFees =
+        switch (type) {
+          case ACCOUNTING -> feeRepository.findAllByDueDatetimeBetween(dayStart, dayEnd);
+          case RECEIPT -> feeRepository.findAllByStatusHistoriesDatetimeBetween(dayStart, dayEnd);
+        };
 
     Collection<AdvancedFeeStats> stats =
         feeDao.getAdvancedFeeStatsOnDateBetween(fromDate, toDate, type).values();

--- a/src/test/java/school/hei/haapi/integration/AdvancedFeeStatsServiceIT.java
+++ b/src/test/java/school/hei/haapi/integration/AdvancedFeeStatsServiceIT.java
@@ -17,6 +17,7 @@ import static school.hei.haapi.integration.conf.TestUtils.setUpCasdoor;
 import static school.hei.haapi.integration.conf.TestUtils.setUpCognito;
 import static school.hei.haapi.integration.conf.TestUtils.setUpEventBridge;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsCountType.ACCOUNTING;
+import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsCountType.RECEIPT;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -157,6 +158,25 @@ class AdvancedFeeStatsServiceIT extends FacadeITMockedThirdParties {
   }
 
   @Test
+  void receipt_fee_due_june_paid_july_counts_as_paid_july() {
+    when(feeRepositoryMock.findAllByStatusHistoriesDatetimeBetween(any(), any()))
+        .thenReturn(feeDueJunePaidInJuly);
+    subject.updateAdvancedFeeStats(
+        Optional.of(Instant.parse("2025-06-01T00:00:00Z")),
+        Optional.of(Instant.parse("2025-07-31T23:59:59Z")),
+        Optional.of(RECEIPT));
+
+    var generatedJuneStats =
+        subject.getAdvancedFeeStats(
+            LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30), Optional.of(RECEIPT));
+    var generatedJulyStats =
+        subject.getAdvancedFeeStats(
+            LocalDate.of(2025, 7, 1), LocalDate.of(2025, 7, 31), Optional.of(RECEIPT));
+    assertEquals(0, generatedJuneStats.getPaidFeesCount().getMonthly());
+    assertEquals(1, generatedJulyStats.getPaidFeesCount().getMonthly());
+  }
+
+  @Test
   void request_accounting_not_available_trigger_generation() {
     var generatedAugustStats =
         subject.getAdvancedFeeStats(
@@ -185,9 +205,32 @@ class AdvancedFeeStatsServiceIT extends FacadeITMockedThirdParties {
     var generatedMayStats =
         subject.getAdvancedFeeStats(
             LocalDate.of(2025, 5, 1), LocalDate.of(2025, 5, 31), Optional.empty());
-    System.out.println(generatedJuneStats);
     assertEquals(1, generatedJuneStats.getPaidFeesCount().getMonthly());
     assertEquals(0, generatedMayStats.getPaidFeesCount().getMonthly());
+  }
+
+  @Test
+  void receipt_fee_due_june_paid_may_counts_as_paid_may() {
+    when(feeRepositoryMock.findAllByStatusHistoriesDatetimeBetween(any(), any()))
+        .thenReturn(feeDueJunePaidInMay);
+    subject.updateAdvancedFeeStats(
+        Optional.of(Instant.parse("2025-05-01T00:00:00Z")),
+        Optional.of(Instant.parse("2025-05-30T23:59:59Z")),
+        Optional.of(RECEIPT));
+    when(feeRepositoryMock.findAllByDueDatetimeBetween(any(), any())).thenReturn(List.of());
+    subject.updateAdvancedFeeStats(
+        Optional.of(Instant.parse("2025-05-01T00:00:00Z")),
+        Optional.of(Instant.parse("2025-06-30T23:59:59Z")),
+        Optional.of(RECEIPT));
+
+    var generatedJuneStats =
+        subject.getAdvancedFeeStats(
+            LocalDate.of(2025, 6, 1), LocalDate.of(2025, 6, 30), Optional.of(RECEIPT));
+    var generatedMayStats =
+        subject.getAdvancedFeeStats(
+            LocalDate.of(2025, 5, 1), LocalDate.of(2025, 5, 31), Optional.of(RECEIPT));
+    assertEquals(0, generatedJuneStats.getPaidFeesCount().getMonthly());
+    assertEquals(1, generatedMayStats.getPaidFeesCount().getMonthly());
   }
 
   @Test

--- a/src/test/java/school/hei/haapi/integration/AdvancedFeeStatsServiceIT.java
+++ b/src/test/java/school/hei/haapi/integration/AdvancedFeeStatsServiceIT.java
@@ -163,6 +163,10 @@ class AdvancedFeeStatsServiceIT extends FacadeITMockedThirdParties {
         .thenReturn(feeDueJunePaidInJuly);
     subject.updateAdvancedFeeStats(
         Optional.of(Instant.parse("2025-06-01T00:00:00Z")),
+        Optional.of(Instant.parse("2025-06-30T23:59:59Z")),
+        Optional.of(RECEIPT));
+    subject.updateAdvancedFeeStats(
+        Optional.of(Instant.parse("2025-07-01T00:00:00Z")),
         Optional.of(Instant.parse("2025-07-31T23:59:59Z")),
         Optional.of(RECEIPT));
 
@@ -215,11 +219,12 @@ class AdvancedFeeStatsServiceIT extends FacadeITMockedThirdParties {
         .thenReturn(feeDueJunePaidInMay);
     subject.updateAdvancedFeeStats(
         Optional.of(Instant.parse("2025-05-01T00:00:00Z")),
-        Optional.of(Instant.parse("2025-05-30T23:59:59Z")),
+        Optional.of(Instant.parse("2025-05-31T23:59:59Z")),
         Optional.of(RECEIPT));
-    when(feeRepositoryMock.findAllByDueDatetimeBetween(any(), any())).thenReturn(List.of());
+    when(feeRepositoryMock.findAllByStatusHistoriesDatetimeBetween(any(), any()))
+        .thenReturn(List.of());
     subject.updateAdvancedFeeStats(
-        Optional.of(Instant.parse("2025-05-01T00:00:00Z")),
+        Optional.of(Instant.parse("2025-06-01T00:00:00Z")),
         Optional.of(Instant.parse("2025-06-30T23:59:59Z")),
         Optional.of(RECEIPT));
 
@@ -229,8 +234,8 @@ class AdvancedFeeStatsServiceIT extends FacadeITMockedThirdParties {
     var generatedMayStats =
         subject.getAdvancedFeeStats(
             LocalDate.of(2025, 5, 1), LocalDate.of(2025, 5, 31), Optional.of(RECEIPT));
-    assertEquals(0, generatedJuneStats.getPaidFeesCount().getMonthly());
     assertEquals(1, generatedMayStats.getPaidFeesCount().getMonthly());
+    assertEquals(0, generatedJuneStats.getPaidFeesCount().getMonthly());
   }
 
   @Test

--- a/src/test/java/school/hei/haapi/integration/AdvancedFeeStatsServiceIT.java
+++ b/src/test/java/school/hei/haapi/integration/AdvancedFeeStatsServiceIT.java
@@ -159,7 +159,7 @@ class AdvancedFeeStatsServiceIT extends FacadeITMockedThirdParties {
 
   @Test
   void receipt_fee_due_june_paid_july_counts_as_paid_july() {
-    when(feeRepositoryMock.findAllByStatusHistoriesDatetimeBetween(any(), any()))
+    when(feeRepositoryMock.findDistinctByStatusHistoriesDatetimeBetween(any(), any()))
         .thenReturn(feeDueJunePaidInJuly);
     subject.updateAdvancedFeeStats(
         Optional.of(Instant.parse("2025-06-01T00:00:00Z")),
@@ -215,13 +215,13 @@ class AdvancedFeeStatsServiceIT extends FacadeITMockedThirdParties {
 
   @Test
   void receipt_fee_due_june_paid_may_counts_as_paid_may() {
-    when(feeRepositoryMock.findAllByStatusHistoriesDatetimeBetween(any(), any()))
+    when(feeRepositoryMock.findDistinctByStatusHistoriesDatetimeBetween(any(), any()))
         .thenReturn(feeDueJunePaidInMay);
     subject.updateAdvancedFeeStats(
         Optional.of(Instant.parse("2025-05-01T00:00:00Z")),
         Optional.of(Instant.parse("2025-05-31T23:59:59Z")),
         Optional.of(RECEIPT));
-    when(feeRepositoryMock.findAllByStatusHistoriesDatetimeBetween(any(), any()))
+    when(feeRepositoryMock.findDistinctByStatusHistoriesDatetimeBetween(any(), any()))
         .thenReturn(List.of());
     subject.updateAdvancedFeeStats(
         Optional.of(Instant.parse("2025-06-01T00:00:00Z")),

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -107,7 +107,8 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
                 .countType(RECEIPT)
                 .build());
 
-    when(feeRepository.findAllByDueDatetimeBetween(any(), any())).thenReturn(getFeeList());
+    when(feeRepository.findAllByStatusHistoriesDatetimeBetween(any(), any()))
+        .thenReturn(getFeeList());
     when(feeDao.getAdvancedFeeStatsOnDateBetween(any(), any(), any())).thenReturn(Map.of());
     List<AdvancedFeeStats> stats = subject.generateAdvancedFeeStats(rangeDate, rangeDate, RECEIPT);
     Set<AdvancedFeeStats> actualStats =

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -107,7 +107,7 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
                 .countType(RECEIPT)
                 .build());
 
-    when(feeRepository.findAllByStatusHistoriesDatetimeBetween(any(), any()))
+    when(feeRepository.findDistinctByStatusHistoriesDatetimeBetween(any(), any()))
         .thenReturn(getFeeList());
     when(feeDao.getAdvancedFeeStatsOnDateBetween(any(), any(), any())).thenReturn(Map.of());
     List<AdvancedFeeStats> stats = subject.generateAdvancedFeeStats(rangeDate, rangeDate, RECEIPT);


### PR DESCRIPTION
Generates advanced fee stats for the RECEIPT type. The other one being the ACCOUNTING type which was implemented. 

For further reference on the difference between the two, please refer to the following conversation. 

<img width="1433" height="774" alt="image" src="https://github.com/user-attachments/assets/629a1410-5a8d-48b0-a108-946b9adbc80b" />
