### PR TITLE
chore: save all transactions in xlsx during verification and update mpbs accordignly

### DIFF
--- a/src/main/java/school/hei/haapi/service/ComputeVerifiedMobilePayment.java
+++ b/src/main/java/school/hei/haapi/service/ComputeVerifiedMobilePayment.java
@@ -46,6 +46,7 @@ public class ComputeVerifiedMobilePayment {
     mpbs.setStatus(SUCCESS);
     mpbs.setPspOwnDatetimeVerification(
         correspondingMobileTransaction.getPspOwnDatetimeVerification());
+    mpbs.setAmount(correspondingMobileTransaction.getPspTransactionAmount());
     var successfullyVerifiedMpbs = mpbsService.save(mpbs);
 
     // ... then save the verification

--- a/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
+++ b/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
@@ -31,7 +31,6 @@ import school.hei.haapi.http.model.TransactionDetails;
 import school.hei.haapi.model.MobileTransactionDetails;
 import school.hei.haapi.model.Mpbs.Mpbs;
 import school.hei.haapi.model.Mpbs.MpbsVerification;
-import school.hei.haapi.model.Mpbs.TypedMobileMoneyTransaction;
 import school.hei.haapi.model.exception.NoRemainingAmountFee;
 import school.hei.haapi.repository.MpbsRepository;
 import school.hei.haapi.repository.MpbsVerificationRepository;
@@ -145,10 +144,6 @@ public class MpbsVerificationService {
 
   private List<String> generateMobileTransactionDetailsFromXlsFile(File file) throws IOException {
     log.info("Reading XLS file...");
-    List<String> pendingMpbsPspIds =
-        mpbsRepository.findAllByStatus(PENDING).stream()
-            .map(TypedMobileMoneyTransaction::getPspId)
-            .toList();
 
     List<MobileTransactionDetails> transactions = new ArrayList<>();
 
@@ -176,8 +171,7 @@ public class MpbsVerificationService {
           dateCell.getStringCellValue().trim() + " " + timeCell.getStringCellValue().trim();
       String ref = refCell.getStringCellValue().trim();
 
-      if (pendingMpbsPspIds.contains(ref)) {
-
+      if (ref.matches("^MP.{18}$")) {
         Instant transactionCreationTime;
         try {
           transactionCreationTime = Instant.from(convertStringToInstant(dateTimeStr));

--- a/src/main/java/school/hei/haapi/service/UnverifiedMobilePaymentHandler.java
+++ b/src/main/java/school/hei/haapi/service/UnverifiedMobilePaymentHandler.java
@@ -40,7 +40,7 @@ public class UnverifiedMobilePaymentHandler implements Consumer<List<Mpbs>> {
           "Update mpbs status failed, mpbs: {} is already successfully verified", mpbs.getId());
       return mpbs;
     }
-    log.info("update the payment {} for the fee {}", mpbs.getId(), mpbs.getFee());
+    log.info("Update the payment {} for the fee {}", mpbs.getId(), mpbs.getFee());
     return mpbs.toBuilder()
         .fee(mpbs.getFee())
         .lastVerificationDatetime(now)

--- a/src/main/java/school/hei/haapi/service/event/PendingMpbsCheckRequestedService.java
+++ b/src/main/java/school/hei/haapi/service/event/PendingMpbsCheckRequestedService.java
@@ -75,7 +75,6 @@ public class PendingMpbsCheckRequestedService implements Consumer<PendingMpbsChe
         correspondingMobileTransaction.getPspOwnDatetimeVerification());
     if (SUCCESS.equals(mpbsNewStatus)) {
       mpbs.setAmount(correspondingMobileTransaction.getPspTransactionAmount());
-      ;
     }
     var successfullyVerifiedMpbs = mpbsService.save(mpbs);
     log.info("Mpbs has successfully verified = {}", mpbs);

--- a/src/main/java/school/hei/haapi/service/event/PendingMpbsCheckRequestedService.java
+++ b/src/main/java/school/hei/haapi/service/event/PendingMpbsCheckRequestedService.java
@@ -67,12 +67,18 @@ public class PendingMpbsCheckRequestedService implements Consumer<PendingMpbsChe
             .build();
 
     // Update mpbs ...
+    var mpbsNewStatus =
+        defineMpbsStatusFromOrangeTransactionDetails(correspondingMobileTransaction);
     mpbs.setSuccessfullyVerifiedOn(now);
-    mpbs.setStatus(defineMpbsStatusFromOrangeTransactionDetails(correspondingMobileTransaction));
+    mpbs.setStatus(mpbsNewStatus);
     mpbs.setPspOwnDatetimeVerification(
         correspondingMobileTransaction.getPspOwnDatetimeVerification());
+    if (SUCCESS.equals(mpbsNewStatus)) {
+      mpbs.setAmount(correspondingMobileTransaction.getPspTransactionAmount());
+      ;
+    }
     var successfullyVerifiedMpbs = mpbsService.save(mpbs);
-    log.info("Mpbs has successfully verified = {}", mpbs.toString());
+    log.info("Mpbs has successfully verified = {}", mpbs);
 
     // ... then save the verification
     verifiedMobileTransaction.setMobileMoneyType(successfullyVerifiedMpbs.getMobileMoneyType());


### PR DESCRIPTION
This fixes issues where failed transactions being changed to pending are not considered in the verification when the `CheckMobilePaymentTransactionScheduler` is running, and also update the mpbs amount when the payment is successful.