### PR TITLE
fix: handle runtime exceptions in mpbs verifications

### DIFF
--- a/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
+++ b/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
@@ -80,43 +80,44 @@ public class MpbsVerificationService {
                   Comparator.comparing(
                       MobileTransactionDetails::getPspDatetimeTransactionCreation));
 
-      if (correspondingTransactionPendingDetails.isPresent()) {
-        MobileTransactionDetails lastTransactionDetails =
-            correspondingTransactionPendingDetails.get();
-        if (SUCCESS.equals(lastTransactionDetails.getStatus())) {
-          try {
-            log.info("mobile transaction found = {}", lastTransactionDetails);
-            TransactionDetails transactionDetails =
-                externalResponseMapper.toExternalTransactionDetails(lastTransactionDetails);
-            log.info("mapped transaction details = {}", transactionDetails);
-
-            verifiedMpbs.add(
-                computeVerifiedMobilePayment.saveTheVerifiedMpbs(pendingMbps, transactionDetails));
-          } catch (NoRemainingAmountFee e) {
-            log.error(
-                "payment %s could not be verified because fee %s has no remaining amount"
-                    .formatted(pendingMbps.getId(), pendingMbps.getFee().getId()),
-                e);
-          } catch (RuntimeException e) {
-            log.error(
-                "Mpbs of ref {} could not be verified because of error", pendingMbps.getPspId(), e);
-          }
-        } else {
-          log.info(
-              "verification mobile payment details stored is not success for the payment {}",
-              pendingMbps.getId());
-          unverifiedMpbs.add(pendingMbps);
-        }
-      } else {
+      if (!correspondingTransactionPendingDetails.isPresent()) {
         log.info(
             "no verification mobile payment details stored for the payment {}",
             pendingMbps.getId());
         unverifiedMpbs.add(pendingMbps);
+        continue;
+      }
+
+      MobileTransactionDetails lastTransactionDetails =
+          correspondingTransactionPendingDetails.get();
+      if (!SUCCESS.equals(lastTransactionDetails.getStatus())) {
+        log.info(
+            "verification mobile payment details stored is not success for the payment {}",
+            pendingMbps.getId());
+        unverifiedMpbs.add(pendingMbps);
+        continue;
+      }
+
+      try {
+        log.info("mobile transaction found = {}", lastTransactionDetails);
+        TransactionDetails transactionDetails =
+            externalResponseMapper.toExternalTransactionDetails(lastTransactionDetails);
+        log.info("mapped transaction details = {}", transactionDetails);
+
+        verifiedMpbs.add(
+            computeVerifiedMobilePayment.saveTheVerifiedMpbs(pendingMbps, transactionDetails));
+      } catch (NoRemainingAmountFee e) {
+        log.error(
+            "payment %s could not be verified because fee %s has no remaining amount"
+                .formatted(pendingMbps.getId(), pendingMbps.getFee().getId()),
+            e);
+      } catch (RuntimeException e) {
+        log.error(
+            "Mpbs of ref {} could not be verified because of error", pendingMbps.getPspId(), e);
       }
     }
 
     unverifiedMobilePaymentHandler.accept(unverifiedMpbs);
-
     return verifiedMpbs;
   }
 

--- a/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
+++ b/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
@@ -97,6 +97,11 @@ public class MpbsVerificationService {
                 "payment %s could not be verified because fee %s has no remaining amount"
                     .formatted(pendingMbps.getId(), pendingMbps.getFee().getId()),
                 e);
+          } catch (RuntimeException e) {
+            log.error(
+                "Mpbs of ref {} could not be verified because of error {}",
+                pendingMbps.getPspId(),
+                e.getMessage());
           }
         } else {
           log.info(

--- a/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
+++ b/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
@@ -99,7 +99,6 @@ public class MpbsVerificationService {
       }
 
       try {
-        log.info("mobile transaction found = {}", lastTransactionDetails);
         TransactionDetails transactionDetails =
             externalResponseMapper.toExternalTransactionDetails(lastTransactionDetails);
         log.info("mapped transaction details = {}", transactionDetails);

--- a/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
+++ b/src/main/java/school/hei/haapi/service/MpbsVerificationService.java
@@ -99,9 +99,7 @@ public class MpbsVerificationService {
                 e);
           } catch (RuntimeException e) {
             log.error(
-                "Mpbs of ref {} could not be verified because of error {}",
-                pendingMbps.getPspId(),
-                e.getMessage());
+                "Mpbs of ref {} could not be verified because of error", pendingMbps.getPspId(), e);
           }
         } else {
           log.info(


### PR DESCRIPTION
Mpbs verification is done in asynchronous and when a verification of one mpbs fails, we should continue for others not stop the entire process