### PR TITLE
fix: enable repeater grades for previous groups

### DIFF
--- a/src/main/java/school/hei/haapi/service/GradeService.java
+++ b/src/main/java/school/hei/haapi/service/GradeService.java
@@ -37,6 +37,7 @@ import school.hei.haapi.endpoint.rest.model.ImportGradeStat;
 import school.hei.haapi.file.bucket.BucketComponent;
 import school.hei.haapi.model.Grade;
 import school.hei.haapi.model.Group;
+import school.hei.haapi.model.GroupFlow;
 import school.hei.haapi.model.dto.GradeImportDto;
 import school.hei.haapi.model.exception.BadRequestException;
 import school.hei.haapi.model.exception.NotFoundException;
@@ -88,8 +89,7 @@ public class GradeService {
         .orElseThrow(() -> new NotFoundException("grade with id " + id + " not found"));
   }
 
-  // TODO: make this obey the single-responsibility rule, at least in the name.
-  private Grade checkGradeToCreate(Grade grade) {
+  public Grade checkGradeToCreate(Grade grade) {
     String examId = grade.getExam().getId();
     String studentId = grade.getStudent().getId();
 
@@ -101,9 +101,11 @@ public class GradeService {
       throw new BadRequestException(error);
     }
 
+    var studentGroups =
+        grade.getStudent().getGroupFlows().stream().map(GroupFlow::getGroup).toList();
     boolean isInAssignedGroup =
         grade.getExam().getCourseAssignment().getGroups().stream()
-            .anyMatch(group -> group.getId().equals(studentGroup.get().getId()));
+            .anyMatch(studentGroups::contains);
     if (!isInAssignedGroup) {
       String error = String.format("Student with id %s is not in exam %s", studentId, examId);
       throw new BadRequestException(error);

--- a/src/test/java/school/hei/haapi/integration/test_data/GroupTestData.java
+++ b/src/test/java/school/hei/haapi/integration/test_data/GroupTestData.java
@@ -37,4 +37,14 @@ public class GroupTestData {
         .groupFlowType(GroupFlow.GroupFlowType.JOIN)
         .build();
   }
+
+  public static GroupFlow createGroupFlowAt(User student, Group toJoin, Instant flowDatetime) {
+    return GroupFlow.builder()
+        .id(randomUUID().toString())
+        .group(toJoin)
+        .flowDatetime(flowDatetime)
+        .student(student)
+        .groupFlowType(GroupFlow.GroupFlowType.JOIN)
+        .build();
+  }
 }

--- a/src/test/java/school/hei/haapi/service/GradeServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/GradeServiceTest.java
@@ -4,13 +4,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static school.hei.haapi.integration.test_data.CourseAssignmentTestData.createCourseAssignment;
+import static school.hei.haapi.integration.test_data.CourseTestData.prog1;
+import static school.hei.haapi.integration.test_data.ExamTestData.createExam;
+import static school.hei.haapi.integration.test_data.GroupTestData.createGroupFlowAt;
+import static school.hei.haapi.integration.test_data.GroupTestData.g1;
+import static school.hei.haapi.integration.test_data.GroupTestData.g2;
+import static school.hei.haapi.integration.test_data.TeacherTestData.toky;
 
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import school.hei.haapi.endpoint.rest.model.ExamGradeStats;
 import school.hei.haapi.integration.conf.FacadeITMockedThirdParties;
+import school.hei.haapi.integration.test_data.StudentTestData;
 import school.hei.haapi.model.Grade;
 import school.hei.haapi.model.exception.NotFoundException;
 import school.hei.haapi.repository.dao.GradeDao;
@@ -39,5 +48,28 @@ class GradeServiceTest extends FacadeITMockedThirdParties {
         assertThrows(NotFoundException.class, () -> subject.getExamGradeStats(examId));
 
     assertEquals("Exam with id " + examId + " do not have a score", exception.getMessage());
+  }
+
+  @Test
+  void createParticipantGrade_forPreviousGroup_ok() {
+    var studentAxel = StudentTestData.axel();
+    var oldGroup = g1();
+    var newGroup = g2();
+    var joinOldGroup =
+        createGroupFlowAt(studentAxel, oldGroup, Instant.parse("2026-01-13T08:00:00Z"));
+    var joinNewGroup =
+        createGroupFlowAt(studentAxel, newGroup, Instant.parse("2026-01-20T08:00:00Z"));
+    studentAxel.setGroupFlows(List.of(joinOldGroup, joinNewGroup));
+    var assignProg1toOldGroup = createCourseAssignment(prog1(), toky(), List.of(oldGroup));
+    var prog1Exam = createExam(Instant.now(), assignProg1toOldGroup);
+    var toCreate =
+        Grade.builder()
+            .score(10.00)
+            .student(studentAxel)
+            .exam(prog1Exam)
+            .creationDatetime(Instant.now())
+            .build();
+
+    assertEquals(toCreate, subject.checkGradeToCreate(toCreate));
   }
 }

--- a/src/test/java/school/hei/haapi/service/GradeServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/GradeServiceTest.java
@@ -14,19 +14,36 @@ import static school.hei.haapi.integration.test_data.TeacherTestData.toky;
 
 import java.time.Instant;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import school.hei.haapi.endpoint.rest.model.ExamGradeStats;
 import school.hei.haapi.integration.conf.FacadeITMockedThirdParties;
 import school.hei.haapi.integration.test_data.StudentTestData;
+import school.hei.haapi.model.Course;
 import school.hei.haapi.model.Grade;
+import school.hei.haapi.model.Group;
+import school.hei.haapi.model.User;
+import school.hei.haapi.model.exception.BadRequestException;
 import school.hei.haapi.model.exception.NotFoundException;
 import school.hei.haapi.repository.dao.GradeDao;
 
 class GradeServiceTest extends FacadeITMockedThirdParties {
   @MockBean private GradeDao gradeDaoMock;
   @Autowired private GradeService subject;
+  private User studentAxel;
+  private Course prog1;
+  private Group g1;
+  private Group g2;
+
+  @BeforeEach
+  void setUp() {
+    studentAxel = StudentTestData.axel();
+    prog1 = prog1();
+    g1 = g1();
+    g2 = g2();
+  }
 
   @Test
   void correct_exam_grade_stats() {
@@ -52,16 +69,11 @@ class GradeServiceTest extends FacadeITMockedThirdParties {
 
   @Test
   void createParticipantGrade_forPreviousGroup_ok() {
-    var studentAxel = StudentTestData.axel();
-    var oldGroup = g1();
-    var newGroup = g2();
-    var joinOldGroup =
-        createGroupFlowAt(studentAxel, oldGroup, Instant.parse("2026-01-13T08:00:00Z"));
-    var joinNewGroup =
-        createGroupFlowAt(studentAxel, newGroup, Instant.parse("2026-01-20T08:00:00Z"));
-    studentAxel.setGroupFlows(List.of(joinOldGroup, joinNewGroup));
-    var assignProg1toOldGroup = createCourseAssignment(prog1(), toky(), List.of(oldGroup));
-    var prog1Exam = createExam(Instant.now(), assignProg1toOldGroup);
+    var joinG1 = createGroupFlowAt(studentAxel, g1, Instant.parse("2026-01-13T08:00:00Z"));
+    var joinG2 = createGroupFlowAt(studentAxel, g2, Instant.parse("2026-01-20T08:00:00Z"));
+    studentAxel.setGroupFlows(List.of(joinG1, joinG2));
+    var assignProg1ToG1 = createCourseAssignment(prog1(), toky(), List.of(g1));
+    var prog1Exam = createExam(Instant.now(), assignProg1ToG1);
     var toCreate =
         Grade.builder()
             .score(10.00)
@@ -71,5 +83,51 @@ class GradeServiceTest extends FacadeITMockedThirdParties {
             .build();
 
     assertEquals(toCreate, subject.checkGradeToCreate(toCreate));
+  }
+
+  @Test
+  void createParticipantGrade_forUnanssignedStudent_ko() {
+    var joinG1 = createGroupFlowAt(studentAxel, g1, Instant.parse("2026-01-13T08:00:00Z"));
+    studentAxel.setGroupFlows(List.of(joinG1));
+    var assignProg1ToG2 = createCourseAssignment(prog1(), toky(), List.of(g2));
+    var prog1Exam = createExam(Instant.now(), assignProg1ToG2);
+    var toCreate =
+        Grade.builder()
+            .score(10.00)
+            .student(studentAxel)
+            .exam(prog1Exam)
+            .creationDatetime(Instant.now())
+            .build();
+
+    assertThrows(
+        BadRequestException.class,
+        () -> subject.checkGradeToCreate(toCreate),
+        "Student with id "
+            + studentAxel.getId()
+            + " is not in exam "
+            + prog1Exam.getId()
+            + " assignment "
+            + assignProg1ToG2.getId()
+            + " group "
+            + prog1Exam.getId());
+  }
+
+  @Test
+  void createParticipantGrade_forGrouplessStudent_ko() {
+    studentAxel.setGroupFlows(List.of());
+    var assignProg1ToG1 = createCourseAssignment(prog1(), toky(), List.of(g1));
+    var prog1Exam = createExam(Instant.now(), assignProg1ToG1);
+    var toCreate =
+        Grade.builder()
+            .score(10.00)
+            .student(studentAxel)
+            .exam(prog1Exam)
+            .creationDatetime(Instant.now())
+            .build();
+
+    assertThrows(
+        BadRequestException.class,
+        () -> subject.checkGradeToCreate(toCreate),
+        "Student with id " + studentAxel.getId() + " is not in any group");
   }
 }


### PR DESCRIPTION
This small fix is used to allow **adding grades for repeaters for their previous groups**. 

It used to be impossible, as they no longer belonged to that group, throwing an error saying that they are no longer a part of the groups assigned to that exam... yet, they _used_ to be. 