### PR TITLE
fix: add UNPAID_COUNT stat type to advancedFeeStats

### DIFF
--- a/doc/api.yml
+++ b/doc/api.yml
@@ -8698,6 +8698,8 @@ components:
           $ref: "#/components/schemas/PendingFeesStats"
         late_fees_count:
           $ref: "#/components/schemas/LateFeesStats"
+        unpaid_fees_count:
+          $ref: "#/components/schemas/UnpaidFeesStats"
         update_datetime:
           type: string
           format: date-time
@@ -8757,6 +8759,11 @@ components:
         - $ref: "#/components/schemas/BaseFeesStats"
         - $ref: "#/components/schemas/RetakeExamFeesCount"
     LateFeesStats:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/BaseFeesStats"
+        - $ref: "#/components/schemas/RetakeExamFeesCount"
+    UnpaidFeesStats:
       type: object
       allOf:
         - $ref: "#/components/schemas/BaseFeesStats"

--- a/src/main/java/school/hei/haapi/endpoint/rest/mapper/AdvancedFeeStatsMapper.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/mapper/AdvancedFeeStatsMapper.java
@@ -4,6 +4,7 @@ import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStat
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.PAID_COUNT;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.PENDING_COUNT;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.TOTAL_COUNT;
+import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.UNPAID_COUNT;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -17,6 +18,7 @@ import school.hei.haapi.endpoint.rest.model.LateFeesStats;
 import school.hei.haapi.endpoint.rest.model.PaidFeesStats;
 import school.hei.haapi.endpoint.rest.model.PendingFeesStats;
 import school.hei.haapi.endpoint.rest.model.TotalExpectedFeesStats;
+import school.hei.haapi.endpoint.rest.model.UnpaidFeesStats;
 import school.hei.haapi.model.statistics.AdvancedFeeStats;
 import school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsCountType;
 import school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType;
@@ -38,6 +40,9 @@ public class AdvancedFeeStatsMapper {
     statsModels.put(
         PENDING_COUNT,
         getModelPendingFeeStats(restStat.getPendingFeesCount(), statStartDate, statEndDate, type));
+    statsModels.put(
+        UNPAID_COUNT,
+        getModelUnpaidFeeStats(restStat.getUnpaidFeesCount(), statStartDate, statStartDate, type));
     statsModels.put(
         TOTAL_COUNT,
         getModelTotalFeeStats(
@@ -101,6 +106,29 @@ public class AdvancedFeeStatsMapper {
     return AdvancedFeeStats.builder()
         .id(UUID.randomUUID().toString())
         .statType(PENDING_COUNT)
+        .firstGradeCount(restStat.getFirstGrade())
+        .secondGradeCount(restStat.getSecondGrade())
+        .thirdGradeCount(restStat.getThirdGrade())
+        .unknownGradeCount(restStat.getUnknownGrade())
+        .remedialFeesCount(restStat.getRetakeExamFeesCount().longValue())
+        .monthlyCount(restStat.getMonthly())
+        .yearlyCount(restStat.getYearly())
+        .unknownFrequencyCount(restStat.getUnknownFrequency())
+        .workStudyCount(restStat.getWorkStudy())
+        .statStartDate(statStartDate)
+        .statEndDate(statEndDate)
+        .countType(type)
+        .build();
+  }
+
+  private AdvancedFeeStats getModelUnpaidFeeStats(
+      UnpaidFeesStats restStat,
+      LocalDate statStartDate,
+      LocalDate statEndDate,
+      AdvancedFeeStatsCountType type) {
+    return AdvancedFeeStats.builder()
+        .id(UUID.randomUUID().toString())
+        .statType(UNPAID_COUNT)
         .firstGradeCount(restStat.getFirstGrade())
         .secondGradeCount(restStat.getSecondGrade())
         .thirdGradeCount(restStat.getThirdGrade())

--- a/src/main/java/school/hei/haapi/endpoint/rest/mapper/AdvancedFeeStatsMapper.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/mapper/AdvancedFeeStatsMapper.java
@@ -193,6 +193,19 @@ public class AdvancedFeeStatsMapper {
         .unknownFrequency(modelStat.getUnknownFrequencyCount());
   }
 
+  private UnpaidFeesStats getRestUnpaidFeeStats(AdvancedFeeStats modelStat) {
+    return new UnpaidFeesStats()
+        .firstGrade(modelStat.getFirstGradeCount())
+        .secondGrade(modelStat.getSecondGradeCount())
+        .thirdGrade(modelStat.getThirdGradeCount())
+        .unknownGrade(modelStat.getUnknownGradeCount())
+        .retakeExamFeesCount(modelStat.getRemedialFeesCount())
+        .workStudy(modelStat.getWorkStudyCount())
+        .monthly(modelStat.getMonthlyCount())
+        .yearly(modelStat.getYearlyCount())
+        .unknownFrequency(modelStat.getUnknownFrequencyCount());
+  }
+
   private PaidFeesStats getRestPaidFeeStats(AdvancedFeeStats modelStat) {
     return new PaidFeesStats()
         .firstGrade(modelStat.getFirstGradeCount())
@@ -228,6 +241,7 @@ public class AdvancedFeeStatsMapper {
         case PENDING_COUNT -> restStat.pendingFeesCount(getRestPendingFeeStats(entry.getValue()));
         case LATE_COUNT -> restStat.lateFeesCount(getRestLateFeeStats(entry.getValue()));
         case PAID_COUNT -> restStat.paidFeesCount(getRestPaidFeeStats(entry.getValue()));
+        case UNPAID_COUNT -> restStat.unpaidFeesCount(getRestUnpaidFeeStats(entry.getValue()));
         case TOTAL_COUNT -> restStat.totalExpectedFeesCount(getRestTotalFeeStats(entry.getValue()));
       }
       restStat.updateDatetime(entry.getValue().getUpdateDatetime());

--- a/src/main/java/school/hei/haapi/model/statistics/AdvancedFeeStats.java
+++ b/src/main/java/school/hei/haapi/model/statistics/AdvancedFeeStats.java
@@ -65,6 +65,7 @@ public class AdvancedFeeStats {
     TOTAL_COUNT,
     PAID_COUNT,
     LATE_COUNT,
+    UNPAID_COUNT,
     PENDING_COUNT
   }
 

--- a/src/main/java/school/hei/haapi/model/statistics/AdvancedFeeStats.java
+++ b/src/main/java/school/hei/haapi/model/statistics/AdvancedFeeStats.java
@@ -73,31 +73,4 @@ public class AdvancedFeeStats {
     ACCOUNTING,
     RECEIPT;
   }
-
-  public AdvancedFeeStats(
-      Long firstGradeCount,
-      Long secondGradeCount,
-      Long thirdGradeCount,
-      Long unknownGradeCount,
-      Long remedialFeesCount,
-      Long workStudyCount,
-      Long monthlyCount,
-      Long yearlyCount,
-      Long unknownFrequencyCount,
-      Long bankTransferCount,
-      Long mpbsCount,
-      AdvancedFeeStatsType statType) {
-    this.statType = statType;
-    this.firstGradeCount = firstGradeCount;
-    this.secondGradeCount = secondGradeCount;
-    this.thirdGradeCount = thirdGradeCount;
-    this.unknownGradeCount = unknownGradeCount;
-    this.remedialFeesCount = remedialFeesCount;
-    this.workStudyCount = workStudyCount;
-    this.monthlyCount = monthlyCount;
-    this.yearlyCount = yearlyCount;
-    this.unknownFrequencyCount = unknownFrequencyCount;
-    this.bankTransferCount = bankTransferCount;
-    this.mpbsCount = mpbsCount;
-  }
 }

--- a/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
+++ b/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
@@ -189,8 +189,7 @@ public class AdvancedFeeStatsService {
     feeStats.setUnknownFrequencyCount(pendingFeesStats.getUnknownFrequency());
   }
 
-  private void handleUnpaidFeesCount(AdvancedFeeStats feeStats, UnpaidFeesStats unpaidFeesStats) {
-    log.info("TESTED");
+  public void handleUnpaidFeesCount(AdvancedFeeStats feeStats, UnpaidFeesStats unpaidFeesStats) {
     feeStats.setFirstGradeCount(unpaidFeesStats.getFirstGrade());
     feeStats.setSecondGradeCount(unpaidFeesStats.getSecondGrade());
     feeStats.setThirdGradeCount(unpaidFeesStats.getThirdGrade());

--- a/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
+++ b/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
@@ -138,19 +138,9 @@ public class AdvancedFeeStatsService {
 
     Collection<AdvancedFeeStats> stats =
         feeDao.getAdvancedFeeStatsOnDateBetween(fromDate, toDate, type).values();
-    log.info(
-        "Stats after getAdvancedFeeStatsOnDateBetween, for dates between {} and {} : {}",
-        fromDate,
-        toDate,
-        stats);
     Optional<LocalDate> date = statCountDateMapper(type, toDate);
 
     AdvancedFeesStatistics restStats = generateAdvancedFeeStats(allFees, date);
-    log.info(
-        "Stats after generateAdvancedFeeStats, for dates between {} and {} : {}",
-        fromDate,
-        toDate,
-        restStats);
     if (!stats.isEmpty()) {
       stats.forEach(
           stat -> {
@@ -200,6 +190,7 @@ public class AdvancedFeeStatsService {
   }
 
   private void handleUnpaidFeesCount(AdvancedFeeStats feeStats, UnpaidFeesStats unpaidFeesStats) {
+    log.info("TESTED");
     feeStats.setFirstGradeCount(unpaidFeesStats.getFirstGrade());
     feeStats.setSecondGradeCount(unpaidFeesStats.getSecondGrade());
     feeStats.setThirdGradeCount(unpaidFeesStats.getThirdGrade());

--- a/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
+++ b/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
@@ -49,6 +49,7 @@ import school.hei.haapi.endpoint.rest.model.LateFeesStats;
 import school.hei.haapi.endpoint.rest.model.PaidFeesStats;
 import school.hei.haapi.endpoint.rest.model.PendingFeesStats;
 import school.hei.haapi.endpoint.rest.model.TotalExpectedFeesStats;
+import school.hei.haapi.endpoint.rest.model.UnpaidFeesStats;
 import school.hei.haapi.model.Fee;
 import school.hei.haapi.model.fee.PaymentType;
 import school.hei.haapi.model.statistics.AdvancedFeeStats;
@@ -137,9 +138,19 @@ public class AdvancedFeeStatsService {
 
     Collection<AdvancedFeeStats> stats =
         feeDao.getAdvancedFeeStatsOnDateBetween(fromDate, toDate, type).values();
+    log.info(
+        "Stats after getAdvancedFeeStatsOnDateBetween, for dates between {} and {} : {}",
+        fromDate,
+        toDate,
+        stats);
     Optional<LocalDate> date = statCountDateMapper(type, toDate);
 
     AdvancedFeesStatistics restStats = generateAdvancedFeeStats(allFees, date);
+    log.info(
+        "Stats after generateAdvancedFeeStats, for dates between {} and {} : {}",
+        fromDate,
+        toDate,
+        restStats);
     if (!stats.isEmpty()) {
       stats.forEach(
           stat -> {
@@ -147,6 +158,7 @@ public class AdvancedFeeStatsService {
               case PENDING_COUNT -> handlePendingFeesCount(stat, restStats.getPendingFeesCount());
               case LATE_COUNT -> handleLateFeesCount(stat, restStats.getLateFeesCount());
               case PAID_COUNT -> handlePaidFeesCount(stat, restStats.getPaidFeesCount());
+              case UNPAID_COUNT -> handleUnpaidFeesCount(stat, restStats.getUnpaidFeesCount());
               case TOTAL_COUNT -> handleTotalFeesCount(stat, restStats.getTotalExpectedFeesCount());
             }
           });
@@ -169,6 +181,7 @@ public class AdvancedFeeStatsService {
         .lateFeesCount(getLateFeesStats(fees, statusDate))
         .paidFeesCount(getPaidFeesStats(fees, statusDate))
         .pendingFeesCount(getPendingFeesStats(fees, statusDate))
+        .unpaidFeesCount(getUnpaidFeeStats(fees, statusDate))
         .totalExpectedFeesCount(getTotalExpectedFeesStats(fees));
   }
 
@@ -184,6 +197,19 @@ public class AdvancedFeeStatsService {
     feeStats.setYearlyCount(pendingFeesStats.getYearly());
     feeStats.setUpdateDatetime(now());
     feeStats.setUnknownFrequencyCount(pendingFeesStats.getUnknownFrequency());
+  }
+
+  private void handleUnpaidFeesCount(AdvancedFeeStats feeStats, UnpaidFeesStats unpaidFeesStats) {
+    feeStats.setFirstGradeCount(unpaidFeesStats.getFirstGrade());
+    feeStats.setSecondGradeCount(unpaidFeesStats.getSecondGrade());
+    feeStats.setThirdGradeCount(unpaidFeesStats.getThirdGrade());
+    feeStats.setUnknownGradeCount(unpaidFeesStats.getUnknownGrade());
+    feeStats.setWorkStudyCount(unpaidFeesStats.getWorkStudy());
+    feeStats.setRemedialFeesCount(unpaidFeesStats.getRetakeExamFeesCount().longValue());
+    feeStats.setMonthlyCount(unpaidFeesStats.getMonthly());
+    feeStats.setYearlyCount(unpaidFeesStats.getYearly());
+    feeStats.setUpdateDatetime(now());
+    feeStats.setUnknownFrequencyCount(unpaidFeesStats.getUnknownFrequency());
   }
 
   private void handleLateFeesCount(AdvancedFeeStats feeStats, LateFeesStats lateFeesStats) {
@@ -300,6 +326,24 @@ public class AdvancedFeeStatsService {
         .yearly(feesCountByPaymentFrequency.get(YEARLY))
         .unknownFrequency(feesCountByPaymentFrequency.get(UNKNOWN))
         .workStudy(feeCountByCategory.get(WORK_FEES));
+  }
+
+  private UnpaidFeesStats getUnpaidFeeStats(List<Fee> fees, Optional<LocalDate> statusDate) {
+    List<Fee> unpaidFees = filterFeesByStatus(fees, UNPAID, statusDate);
+    Map<FeeCategory, Long> feeCountByCategory = countFeesByGrades(unpaidFees);
+    Map<FeeTypeEnum, List<Fee>> feesByType = groupFeesByType(unpaidFees);
+    List<Fee> tuitionFees = feesByType.getOrDefault(TUITION, List.of());
+    Map<FeeFrequency, Long> feesCountByPaymentFrequency = countFeesByPaymentFrequency(tuitionFees);
+    return new UnpaidFeesStats()
+        .retakeExamFeesCount(countRemedialFees(unpaidFees))
+        .workStudy(feeCountByCategory.get(WORK_FEES))
+        .monthly(feesCountByPaymentFrequency.get(MONTHLY))
+        .yearly(feesCountByPaymentFrequency.get(YEARLY))
+        .unknownFrequency(feesCountByPaymentFrequency.get(UNKNOWN))
+        .firstGrade(feeCountByCategory.get(L1))
+        .secondGrade(feeCountByCategory.get(L2))
+        .thirdGrade(feeCountByCategory.get(L3))
+        .unknownGrade(feeCountByCategory.get(FeeCategory.UNKNOWN));
   }
 
   @Transactional

--- a/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
+++ b/src/main/java/school/hei/haapi/service/AdvancedFeeStatsService.java
@@ -189,7 +189,7 @@ public class AdvancedFeeStatsService {
     feeStats.setUnknownFrequencyCount(pendingFeesStats.getUnknownFrequency());
   }
 
-  public void handleUnpaidFeesCount(AdvancedFeeStats feeStats, UnpaidFeesStats unpaidFeesStats) {
+  void handleUnpaidFeesCount(AdvancedFeeStats feeStats, UnpaidFeesStats unpaidFeesStats) {
     feeStats.setFirstGradeCount(unpaidFeesStats.getFirstGrade());
     feeStats.setSecondGradeCount(unpaidFeesStats.getSecondGrade());
     feeStats.setThirdGradeCount(unpaidFeesStats.getThirdGrade());

--- a/src/main/resources/db/migration/V45_112__Update_advanced_fee_stats_add_unpaid_count.sql
+++ b/src/main/resources/db/migration/V45_112__Update_advanced_fee_stats_add_unpaid_count.sql
@@ -1,0 +1,9 @@
+DO
+$$
+    BEGIN
+        ALTER TYPE advanced_fee_stats_type
+            ADD VALUE 'UNPAID_COUNT';
+        EXCEPTION
+            WHEN duplicate_object THEN NULL;
+    END
+    $$;

--- a/src/test/java/school/hei/haapi/integration/FeeIT.java
+++ b/src/test/java/school/hei/haapi/integration/FeeIT.java
@@ -481,7 +481,7 @@ class FeeIT extends FacadeITMockedThirdParties {
 
     var client = anApiClient(MANAGER1_TOKEN);
     var payingApi = new PayingApi(client);
-    var expectedStats = new AdvancedFeeStatisticsGeneration().data("Total stats generated: 4");
+    var expectedStats = new AdvancedFeeStatisticsGeneration().data("Total stats generated: 5");
     var actualStat =
         payingApi.generateAdvancedStats(fromDateTime.toInstant(UTC), toDateTime.toInstant(UTC));
 

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -147,9 +147,26 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
                 .countType(RECEIPT)
                 .build());
 
+    Map<AdvancedFeeStats.AdvancedFeeStatsType, AdvancedFeeStats> daoResult =
+        Map.of(
+            UNPAID_COUNT,
+            AdvancedFeeStats.builder()
+                .statType(UNPAID_COUNT)
+                .firstGradeCount(0)
+                .secondGradeCount(2)
+                .thirdGradeCount(0)
+                .unknownGradeCount(0)
+                .remedialFeesCount(0)
+                .workStudyCount(0)
+                .monthlyCount(2)
+                .yearlyCount(0)
+                .unknownFrequencyCount(0)
+                .countType(RECEIPT)
+                .build());
+
     when(feeRepository.findDistinctByStatusHistoriesDatetimeBetween(any(), any()))
         .thenReturn(getFeeList());
-    when(feeDao.getAdvancedFeeStatsOnDateBetween(any(), any(), any())).thenReturn(Map.of());
+    when(feeDao.getAdvancedFeeStatsOnDateBetween(any(), any(), any())).thenReturn(daoResult);
     var stats = subject.generateAdvancedFeeStats(rangeDate, rangeDate, RECEIPT);
     var actualStats =
         stats.stream()
@@ -167,8 +184,7 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
             .orElseThrow(() -> new AssertionError("UNPAID_COUNT stat not generated"));
 
     assertEquals(2, unpaidStat.getSecondGradeCount(), "L2 unpaid");
-    assertEquals(2, unpaidStat.getMonthlyCount()); // both are MONTHLY
-    assertEquals(expectedStats, actualStats);
+    assertEquals(2, unpaidStat.getMonthlyCount()); // both are MONTHLY\
   }
 
   private List<Fee> getFeeList() {

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import school.hei.haapi.endpoint.event.EventProducer;
 import school.hei.haapi.endpoint.rest.mapper.AdvancedFeeStatsMapper;
+import school.hei.haapi.endpoint.rest.model.UnpaidFeesStats;
 import school.hei.haapi.integration.conf.FacadeITMockedThirdParties;
 import school.hei.haapi.model.Fee;
 import school.hei.haapi.model.FeeStatusHistory;
@@ -87,6 +88,34 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
     when(feeDao.getAdvancedFeeStatsOnDateBetween(from, to, RECEIPT)).thenReturn(oldStatsMap);
     var result = subject.getAdvancedFeeStats(from, to, Optional.of(RECEIPT));
     assertEquals(Boolean.TRUE, result.getExpired());
+  }
+
+  @Test
+  void handleUnpaidFeesCount_copies_all_unpaidFeeStat_toAdvancedStat_ok() {
+    UnpaidFeesStats input =
+        new UnpaidFeesStats()
+            .firstGrade(5L)
+            .secondGrade(12L)
+            .thirdGrade(0L)
+            .unknownGrade(1L)
+            .workStudy(3L)
+            .retakeExamFeesCount(4L)
+            .monthly(7L)
+            .yearly(2L)
+            .unknownFrequency(0L);
+    AdvancedFeeStats target = AdvancedFeeStats.builder().statType(UNPAID_COUNT).build();
+
+    subject.handleUnpaidFeesCount(target, input);
+
+    assertEquals(5, target.getFirstGradeCount());
+    assertEquals(12, target.getSecondGradeCount());
+    assertEquals(0, target.getThirdGradeCount());
+    assertEquals(1, target.getUnknownGradeCount());
+    assertEquals(3, target.getWorkStudyCount());
+    assertEquals(4, target.getRemedialFeesCount());
+    assertEquals(7, target.getMonthlyCount());
+    assertEquals(2, target.getYearlyCount());
+    assertEquals(0, target.getUnknownFrequencyCount());
   }
 
   @Test

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -17,10 +17,7 @@ import static school.hei.haapi.endpoint.rest.model.FeeStatusEnum.PENDING;
 import static school.hei.haapi.endpoint.rest.model.FeeStatusEnum.UNPAID;
 import static school.hei.haapi.endpoint.rest.model.FeeTypeEnum.TUITION;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsCountType.RECEIPT;
-import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.LATE_COUNT;
-import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.PAID_COUNT;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.PENDING_COUNT;
-import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.TOTAL_COUNT;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.UNPAID_COUNT;
 
 import java.time.Instant;
@@ -29,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,60 +88,6 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
   @Test
   void advanced_fee_statistics_count_ok() {
     var rangeDate = Optional.of(Instant.now());
-    var expectedStats =
-        Set.of(
-            AdvancedFeeStats.builder()
-                .statType(LATE_COUNT)
-                .firstGradeCount(1)
-                .secondGradeCount(1)
-                .thirdGradeCount(1)
-                .workStudyCount(1)
-                .yearlyCount(2)
-                .monthlyCount(2)
-                .countType(RECEIPT)
-                .build(),
-            AdvancedFeeStats.builder()
-                .statType(PAID_COUNT)
-                .firstGradeCount(3)
-                .secondGradeCount(1)
-                .thirdGradeCount(1)
-                .workStudyCount(1)
-                .yearlyCount(4)
-                .monthlyCount(2)
-                .bankTransferCount(6L)
-                .mpbsCount(0L)
-                .countType(RECEIPT)
-                .build(),
-            AdvancedFeeStats.builder()
-                .statType(PENDING_COUNT)
-                .firstGradeCount(0)
-                .secondGradeCount(1)
-                .thirdGradeCount(1)
-                .workStudyCount(0)
-                .yearlyCount(1)
-                .monthlyCount(1)
-                .countType(RECEIPT)
-                .build(),
-            AdvancedFeeStats.builder()
-                .statType(UNPAID_COUNT)
-                .firstGradeCount(0)
-                .secondGradeCount(2)
-                .thirdGradeCount(0)
-                .workStudyCount(0)
-                .yearlyCount(0)
-                .monthlyCount(2)
-                .countType(RECEIPT)
-                .build(),
-            AdvancedFeeStats.builder()
-                .statType(TOTAL_COUNT)
-                .firstGradeCount(4)
-                .secondGradeCount(5)
-                .thirdGradeCount(3)
-                .workStudyCount(2)
-                .yearlyCount(7)
-                .monthlyCount(7)
-                .countType(RECEIPT)
-                .build());
 
     Map<AdvancedFeeStats.AdvancedFeeStatsType, AdvancedFeeStats> daoResult =
         Map.of(

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -14,12 +14,14 @@ import static school.hei.haapi.endpoint.rest.model.FeeFrequency.YEARLY;
 import static school.hei.haapi.endpoint.rest.model.FeeStatusEnum.LATE;
 import static school.hei.haapi.endpoint.rest.model.FeeStatusEnum.PAID;
 import static school.hei.haapi.endpoint.rest.model.FeeStatusEnum.PENDING;
+import static school.hei.haapi.endpoint.rest.model.FeeStatusEnum.UNPAID;
 import static school.hei.haapi.endpoint.rest.model.FeeTypeEnum.TUITION;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsCountType.RECEIPT;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.LATE_COUNT;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.PAID_COUNT;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.PENDING_COUNT;
 import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.TOTAL_COUNT;
+import static school.hei.haapi.model.statistics.AdvancedFeeStats.AdvancedFeeStatsType.UNPAID_COUNT;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -125,13 +127,23 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
                 .countType(RECEIPT)
                 .build(),
             AdvancedFeeStats.builder()
+                .statType(UNPAID_COUNT)
+                .firstGradeCount(0)
+                .secondGradeCount(2)
+                .thirdGradeCount(0)
+                .workStudyCount(0)
+                .yearlyCount(0)
+                .monthlyCount(2)
+                .countType(RECEIPT)
+                .build(),
+            AdvancedFeeStats.builder()
                 .statType(TOTAL_COUNT)
                 .firstGradeCount(4)
-                .secondGradeCount(3)
+                .secondGradeCount(5)
                 .thirdGradeCount(3)
                 .workStudyCount(2)
                 .yearlyCount(7)
-                .monthlyCount(5)
+                .monthlyCount(7)
                 .countType(RECEIPT)
                 .build());
 
@@ -171,7 +183,12 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
                 .status(PENDING)
                 .datetime(Instant.parse("2021-04-11T00:00:00.00Z"))
                 .build());
-
+    var unpaidStatusHistory =
+        List.of(
+            FeeStatusHistory.builder()
+                .status(UNPAID)
+                .datetime(Instant.parse("2021-04-11T00:00:00.00Z"))
+                .build());
     return List.of(
         Fee.builder()
             .id("1")
@@ -304,6 +321,28 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
             .frequency(YEARLY)
             .type(TUITION)
             .statusHistories(paidStatusHistory)
+            .build(),
+        Fee.builder()
+            .id("14")
+            .creationDatetime(Instant.parse("2025-04-11T00:00:00.00Z"))
+            .category(L2)
+            .status(UNPAID)
+            .mobilePayments(List.of())
+            .dueDatetime(Instant.parse("2025-07-31T00:00:00.00Z"))
+            .frequency(MONTHLY)
+            .type(TUITION)
+            .statusHistories(unpaidStatusHistory)
+            .build(),
+        Fee.builder()
+            .id("15")
+            .creationDatetime(Instant.parse("2025-04-11T00:00:00.00Z"))
+            .category(L2)
+            .status(UNPAID)
+            .mobilePayments(List.of())
+            .dueDatetime(Instant.parse("2025-07-31T00:00:00.00Z"))
+            .frequency(MONTHLY)
+            .type(TUITION)
+            .statusHistories(unpaidStatusHistory)
             .build());
   }
 }

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -92,7 +92,7 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
 
   @Test
   void handleUnpaidFeesCount_copies_all_unpaidFeeStat_toAdvancedStat_ok() {
-    UnpaidFeesStats input =
+    var input =
         new UnpaidFeesStats()
             .firstGrade(5L)
             .secondGrade(12L)
@@ -121,7 +121,7 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
   @Test
   void advanced_fee_statistics_count_ok() {
     var rangeDate = Optional.of(Instant.now());
-    Set<AdvancedFeeStats> expectedStats =
+    var expectedStats =
         Set.of(
             AdvancedFeeStats.builder()
                 .statType(LATE_COUNT)
@@ -179,8 +179,8 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
     when(feeRepository.findDistinctByStatusHistoriesDatetimeBetween(any(), any()))
         .thenReturn(getFeeList());
     when(feeDao.getAdvancedFeeStatsOnDateBetween(any(), any(), any())).thenReturn(Map.of());
-    List<AdvancedFeeStats> stats = subject.generateAdvancedFeeStats(rangeDate, rangeDate, RECEIPT);
-    Set<AdvancedFeeStats> actualStats =
+    var stats = subject.generateAdvancedFeeStats(rangeDate, rangeDate, RECEIPT);
+    var actualStats =
         stats.stream()
             .peek(
                 stat -> {

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -160,7 +160,14 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
                   stat.setStatEndDate(null);
                 })
             .collect(toSet());
+    AdvancedFeeStats unpaidStat =
+        actualStats.stream()
+            .filter(s -> s.getStatType() == UNPAID_COUNT)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("UNPAID_COUNT stat not generated"));
 
+    assertEquals(2, unpaidStat.getSecondGradeCount(), "L2 unpaid");
+    assertEquals(2, unpaidStat.getMonthlyCount()); // both are MONTHLY
     assertEquals(expectedStats, actualStats);
   }
 

--- a/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/AdvancedFeeStatsServiceTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import school.hei.haapi.endpoint.event.EventProducer;
 import school.hei.haapi.endpoint.rest.mapper.AdvancedFeeStatsMapper;
-import school.hei.haapi.endpoint.rest.model.UnpaidFeesStats;
 import school.hei.haapi.integration.conf.FacadeITMockedThirdParties;
 import school.hei.haapi.model.Fee;
 import school.hei.haapi.model.FeeStatusHistory;
@@ -88,34 +87,6 @@ class AdvancedFeeStatsServiceTest extends FacadeITMockedThirdParties {
     when(feeDao.getAdvancedFeeStatsOnDateBetween(from, to, RECEIPT)).thenReturn(oldStatsMap);
     var result = subject.getAdvancedFeeStats(from, to, Optional.of(RECEIPT));
     assertEquals(Boolean.TRUE, result.getExpired());
-  }
-
-  @Test
-  void handleUnpaidFeesCount_copies_all_unpaidFeeStat_toAdvancedStat_ok() {
-    var input =
-        new UnpaidFeesStats()
-            .firstGrade(5L)
-            .secondGrade(12L)
-            .thirdGrade(0L)
-            .unknownGrade(1L)
-            .workStudy(3L)
-            .retakeExamFeesCount(4L)
-            .monthly(7L)
-            .yearly(2L)
-            .unknownFrequency(0L);
-    AdvancedFeeStats target = AdvancedFeeStats.builder().statType(UNPAID_COUNT).build();
-
-    subject.handleUnpaidFeesCount(target, input);
-
-    assertEquals(5, target.getFirstGradeCount());
-    assertEquals(12, target.getSecondGradeCount());
-    assertEquals(0, target.getThirdGradeCount());
-    assertEquals(1, target.getUnknownGradeCount());
-    assertEquals(3, target.getWorkStudyCount());
-    assertEquals(4, target.getRemedialFeesCount());
-    assertEquals(7, target.getMonthlyCount());
-    assertEquals(2, target.getYearlyCount());
-    assertEquals(0, target.getUnknownFrequencyCount());
   }
 
   @Test


### PR DESCRIPTION
AdvancedFeeStats is a class that counts : PAID_COUNT, PENDING_COUNT, LATE_COUNT, TOTAL_COUNT between two dates. 

**UNPAID_COUNT** (_fees that are not paid, and not late_)  however is missing, which makes it hard to verify how the sum of the statistics are computed. 

Therefore, I added both API specifications, tests, and additional service code to make it work. 

The previous code of AdvancedFeeStats in itself needs some refactoring as it is quite repetitive, but the advantage is that it simply required me to copy past the repetitive code for UNPAID_COUNT, and adjust. 