### PR TITLE
fix: is_deleted handling in joined queries and update @Where annotation

### DIFF
--- a/src/main/java/school/hei/haapi/model/Course.java
+++ b/src/main/java/school/hei/haapi/model/Course.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 import school.hei.haapi.endpoint.rest.model.StudentLevel;
 
 @Entity
@@ -36,7 +36,7 @@ import school.hei.haapi.endpoint.rest.model.StudentLevel;
 @NoArgsConstructor
 @EqualsAndHashCode
 @SQLDelete(sql = "update \"course\" set is_deleted = true where id = ?")
-@Where(clause = "is_deleted = false")
+@SQLRestriction("is_deleted = false")
 public class Course implements Serializable {
   @Id
   @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/school/hei/haapi/model/CourseAssignment.java
+++ b/src/main/java/school/hei/haapi/model/CourseAssignment.java
@@ -25,7 +25,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "\"course_assignment\"")
@@ -37,7 +37,7 @@ import org.hibernate.annotations.Where;
 @NoArgsConstructor
 @EqualsAndHashCode
 @SQLDelete(sql = "update \"course_assignment\" set is_deleted = true where id = ?")
-@Where(clause = "is_deleted = false")
+@SQLRestriction("is_deleted = false")
 public class CourseAssignment implements Serializable {
   // todo: to review all class
   @Id

--- a/src/main/java/school/hei/haapi/model/Event.java
+++ b/src/main/java/school/hei/haapi/model/Event.java
@@ -27,7 +27,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 import school.hei.haapi.endpoint.rest.model.EventType;
 
 @Entity
@@ -38,7 +38,7 @@ import school.hei.haapi.endpoint.rest.model.EventType;
 @AllArgsConstructor
 @NoArgsConstructor
 @SQLDelete(sql = "update \"event\" set is_deleted = true where id = ?")
-@Where(clause = "is_deleted = false")
+@SQLRestriction("is_deleted = false")
 @ToString
 public class Event {
 

--- a/src/main/java/school/hei/haapi/model/Fee.java
+++ b/src/main/java/school/hei/haapi/model/Fee.java
@@ -30,10 +30,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.Filter;
-import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import school.hei.haapi.endpoint.rest.model.FeeCategory;
 import school.hei.haapi.endpoint.rest.model.FeeFrequency;
 import school.hei.haapi.endpoint.rest.model.FeeStatusEnum;
@@ -50,8 +49,7 @@ import school.hei.haapi.model.mpbs.Mpbs;
 @AllArgsConstructor
 @NoArgsConstructor
 @SQLDelete(sql = "update \"fee\" set is_deleted = true where id = ?")
-@FilterDef(name = "undeletedFees", defaultCondition = "is_deleted = false")
-@Filter(name = "undeletedFees")
+@SQLRestriction(" is_deleted = false")
 @EqualsAndHashCode
 public class Fee implements Serializable {
   @Id

--- a/src/main/java/school/hei/haapi/model/Fee.java
+++ b/src/main/java/school/hei/haapi/model/Fee.java
@@ -30,9 +30,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 import school.hei.haapi.endpoint.rest.model.FeeCategory;
 import school.hei.haapi.endpoint.rest.model.FeeFrequency;
 import school.hei.haapi.endpoint.rest.model.FeeStatusEnum;
@@ -49,7 +50,8 @@ import school.hei.haapi.model.mpbs.Mpbs;
 @AllArgsConstructor
 @NoArgsConstructor
 @SQLDelete(sql = "update \"fee\" set is_deleted = true where id = ?")
-@Where(clause = "is_deleted = false")
+@FilterDef(name = "undeletedFees", defaultCondition = "is_deleted = false")
+@Filter(name = "undeletedFees")
 @EqualsAndHashCode
 public class Fee implements Serializable {
   @Id

--- a/src/main/java/school/hei/haapi/model/Group.java
+++ b/src/main/java/school/hei/haapi/model/Group.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "\"group\"")
@@ -35,7 +35,7 @@ import org.hibernate.annotations.Where;
 @AllArgsConstructor
 @NoArgsConstructor
 @SQLDelete(sql = "update \"group\" set is_deleted = true where id = ?")
-@Where(clause = "is_deleted = false")
+@SQLRestriction("is_deleted = false")
 public class Group implements Serializable {
   @Id
   @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/school/hei/haapi/model/Payment.java
+++ b/src/main/java/school/hei/haapi/model/Payment.java
@@ -18,14 +18,13 @@ import java.time.Instant;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "\"payment\"")
@@ -35,8 +34,7 @@ import org.hibernate.annotations.Where;
 @AllArgsConstructor
 @NoArgsConstructor
 @SQLDelete(sql = "update \"payment\" set is_deleted = true where id = ?")
-@Where(clause = "is_deleted = false")
-@EqualsAndHashCode
+@SQLRestriction("is_deleted = false")
 public class Payment implements Serializable {
   @Id
   @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/school/hei/haapi/model/User.java
+++ b/src/main/java/school/hei/haapi/model/User.java
@@ -40,7 +40,7 @@ import lombok.ToString;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 import school.hei.haapi.endpoint.rest.model.Coordinates;
 import school.hei.haapi.endpoint.rest.model.SpecializationField;
 import school.hei.haapi.model.exception.ApiException;
@@ -53,7 +53,7 @@ import school.hei.haapi.model.exception.ApiException;
 @AllArgsConstructor
 @NoArgsConstructor
 @SQLDelete(sql = "update \"user\" set is_deleted = true where id = ?")
-@Where(clause = "is_deleted = false")
+@SQLRestriction("is_deleted = false")
 // TODO: separate to a child table as MANAGER, TEACHER, STUDENT, MONITOR
 public class User implements Serializable {
   @Id

--- a/src/main/java/school/hei/haapi/repository/UserRepository.java
+++ b/src/main/java/school/hei/haapi/repository/UserRepository.java
@@ -167,8 +167,10 @@ public interface UserRepository extends JpaRepository<User, String> {
 
   List<User> findAllByRefIn(List<String> refs);
 
-  @Query("select u from User u join Fee f on u.id = f.student.id where f.status = 'LATE' ")
-  List<User> getStudentsWithUnpaidOrLateFee();
+  @Query(
+      "select u from User u join Fee f on u.id = f.student.id where f.status = 'LATE' and"
+          + " f.isDeleted = false")
+  List<User> getStudentsWithLateFees();
 
   Optional<User> findByRef(@NotBlank(message = "Reference is mandatory") String ref);
 

--- a/src/main/java/school/hei/haapi/service/UserService.java
+++ b/src/main/java/school/hei/haapi/service/UserService.java
@@ -405,8 +405,8 @@ public class UserService {
     return userRepository.findAllStudentsByPromotionId(promotionId);
   }
 
-  public List<User> getStudentsWithUnpaidOrLateFee() {
-    return userRepository.getStudentsWithUnpaidOrLateFee();
+  public List<User> getStudentsWithLateFees() {
+    return userRepository.getStudentsWithLateFees();
   }
 
   public byte[] generateStudentsInEventXlsx(String eventId) {

--- a/src/main/java/school/hei/haapi/service/event/SuspendStudentsWithOverdueFeesService.java
+++ b/src/main/java/school/hei/haapi/service/event/SuspendStudentsWithOverdueFeesService.java
@@ -29,7 +29,7 @@ public class SuspendStudentsWithOverdueFeesService
 
   // Suspends students with overdue fees if it hasn't been done already.
   public void suspendStudentsWithUnpaidOrLateFee() {
-    List<User> students = userService.getStudentsWithUnpaidOrLateFee();
+    List<User> students = userService.getStudentsWithLateFees();
     log.info("list of student with unpaid or late fee : {} ", students);
     for (User student : students) {
       if (!SUSPENDED.equals(student.getStatus()) && !DISABLED.equals(student.getStatus())) {

--- a/src/test/java/school/hei/haapi/conf/EnvConf.java
+++ b/src/test/java/school/hei/haapi/conf/EnvConf.java
@@ -24,5 +24,7 @@ public class EnvConf {
     registry.add("CASDOOR_ENDPOINT", () -> "dummy");
     registry.add("CASDOOR_FRONTEND_URL", () -> "dummy");
     registry.add("CASDOOR_REDIRECT_URL", () -> "dummy");
+    registry.add("VOLA_API_KEY", () -> "dummy");
+    registry.add("VOLA_API_URL", () -> "dummy");
   }
 }

--- a/src/test/java/school/hei/haapi/unit/CheckStudentsStatusTest.java
+++ b/src/test/java/school/hei/haapi/unit/CheckStudentsStatusTest.java
@@ -154,8 +154,7 @@ public class CheckStudentsStatusTest extends MockedThirdParties {
     suspendStudentsWithOverdueFeesService.suspendStudentsWithUnpaidOrLateFee();
 
     // student2 have unpaid or late fee
-    assertTrue(
-        userService.getStudentsWithUnpaidOrLateFee().contains(userService.getById(STUDENT2_ID)));
+    assertTrue(userService.getStudentsWithLateFees().contains(userService.getById(STUDENT2_ID)));
 
     // student2 is still ENABLE, because of the pending Mbps
     assertEquals(1, mpbsService.countPendingOfStudent(STUDENT2_ID));
@@ -164,7 +163,7 @@ public class CheckStudentsStatusTest extends MockedThirdParties {
 
   @Test
   void get_all_students_with_unpaid_or_late_fee_ok() {
-    List<User> studentsWithUnpaidOrLateFee = userRepository.getStudentsWithUnpaidOrLateFee();
+    var studentsWithUnpaidOrLateFee = userRepository.getStudentsWithLateFees();
 
     assertEquals(2, studentsWithUnpaidOrLateFee.size());
     assertTrue(studentsWithUnpaidOrLateFee.contains(student1()));

--- a/src/test/java/school/hei/haapi/unit/SuspendStudentWithOverdueFeesTest.java
+++ b/src/test/java/school/hei/haapi/unit/SuspendStudentWithOverdueFeesTest.java
@@ -38,7 +38,7 @@ class SuspendStudentWithOverdueFeesTest extends FacadeITMockedThirdParties {
     var subject =
         new SuspendStudentsWithOverdueFeesService(userManagerDao, userService, mpbsService);
 
-    when(userService.getStudentsWithUnpaidOrLateFee()).thenReturn(disabledStudents);
+    when(userService.getStudentsWithLateFees()).thenReturn(disabledStudents);
     when(mpbsService.countPendingOfStudent(any())).thenReturn(0L);
 
     subject.suspendStudentsWithUnpaidOrLateFee();


### PR DESCRIPTION
@Where annotation is deprecated and is replaced with @SQLRestriction. 

Also, joined queries does is NOT getting an automatic "is_deleted = false" when using `getStudentsWithLateOrUnpaidFees` which has been renamed to `getStudentsWithLateFees` to better suit what the query does. 