### PR TITLE
docs: add spec for StudentStatusCheckup resource

### DIFF
--- a/doc/api.yml
+++ b/doc/api.yml
@@ -6495,7 +6495,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateAnnouncement'
-
       responses:
         '200':
           description: The announcement created
@@ -6571,7 +6570,70 @@ paths:
           $ref: '#/components/responses/429'
         '500':
           $ref: '#/components/responses/500'
-
+  '/students/{student_id}/StudentStatusCheckup':
+    put:
+      tags:
+        - Student
+      summary: Create or update a student status checkup
+      description: Update StudentStatusCheckup for a given student when an id is provided, create them otherwise
+      operationId: createOrUpdateStudentStatusCheckups
+      requestBody:
+        description: StudentStatusCheckup to create / update
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/CrupdateStudentStatusCheckup'
+      responses: 
+        '200':
+          description: The created or updated StudentStatusCheckups
+          content: 
+            application/json: 
+              schema: 
+                type: array
+                items:
+                  $ref: '#/components/schemas/StudentStatusCheckup'
+        '400':
+          $ref: '#/components/responses/400'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '429':
+          $ref: '#/components/responses/429'
+        '500':
+          $ref: '#/components/responses/500'
+    get:
+      tags:
+        - Student
+      operationId: getStudentStatusCheckup
+      summary: Get all student status checkup for a given student
+      parameters:
+        - name: student_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Set value to 1 by default if null is provided
+      responses:
+        '200':
+          description: All student status checkup asked by teachers
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudentStatusCheckup'
+        '400':
+          $ref: '#/components/responses/400'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '429':
+          $ref: '#/components/responses/429'
+        '500':
+          $ref: '#/components/responses/500'
   '/students/announcements':
     get:
       tags:
@@ -8999,6 +9061,38 @@ components:
       enum:
         - YEARLY
         - MONTHLY
+    StudentStatusCheckup_Status: 
+      type: string
+      enum: 
+        - PENDING
+        - WITHDRAWN
+        - ENROLLED
+    CrupdateStudentStatusCheckup: 
+      type: object 
+      properties: 
+        id: 
+          type: string 
+        student_id: 
+          type: string 
+        teacher_id: 
+          type: string 
+    StudentStatusCheckup: 
+      type: object 
+      properties: 
+        id:
+          type: string
+        student:
+          $ref: '#/components/schemas/UserIdentifier'
+        teacher:
+          $ref: '#/components/schemas/UserIdentifier'
+        status: 
+          $ref: '#/components/schemas/StudentStatusCheckup_Status'
+        creation_datetime: 
+          type: string
+          format: date-time
+        update_datetime: 
+          type: string
+          format: date-time
     CorBase:
       type: object
       properties:

--- a/doc/api.yml
+++ b/doc/api.yml
@@ -6577,6 +6577,12 @@ paths:
       summary: Create or update a student status checkup
       description: Update StudentStatusCheckup for a given student when an id is provided, create them otherwise
       operationId: createOrUpdateStudentStatusCheckups
+      parameters:
+        - name: student_id
+          in: path
+          required: true
+          schema:
+            type: string
       requestBody:
         description: StudentStatusCheckup to create / update
         required: true
@@ -6616,7 +6622,6 @@ paths:
           required: true
           schema:
             type: string
-          description: Set value to 1 by default if null is provided
       responses:
         '200':
           description: All student status checkup asked by teachers

--- a/doc/api.yml
+++ b/doc/api.yml
@@ -9080,7 +9080,9 @@ components:
         student_id: 
           type: string 
         teacher_id: 
-          type: string 
+          type: string
+        description:
+          type: string
     StudentStatusCheckup: 
       type: object 
       properties: 
@@ -9090,6 +9092,8 @@ components:
           $ref: '#/components/schemas/UserIdentifier'
         teacher:
           $ref: '#/components/schemas/UserIdentifier'
+        description:
+          type: string
         status: 
           $ref: '#/components/schemas/StudentStatusCheckup_Status'
         creation_datetime: 

--- a/doc/api.yml
+++ b/doc/api.yml
@@ -6570,13 +6570,13 @@ paths:
           $ref: '#/components/responses/429'
         '500':
           $ref: '#/components/responses/500'
-  '/students/{student_id}/StudentStatusCheckup':
-    put:
+  '/students/{student_id}/status-check':
+    post:
       tags:
         - Student
-      summary: Create or update a student status checkup
-      description: Update StudentStatusCheckup for a given student when an id is provided, create them otherwise
-      operationId: createOrUpdateStudentStatusCheckups
+      summary: Create a student status check
+      description: Create status check for a given student
+      operationId: createStatusCheck
       parameters:
         - name: student_id
           in: path
@@ -6584,23 +6584,63 @@ paths:
           schema:
             type: string
       requestBody:
-        description: StudentStatusCheckup to create / update
+        description: The status checks to create on a given student
         required: true
         content:
           application/json:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/CrupdateStudentStatusCheckup'
-      responses: 
+                $ref: '#/components/schemas/CreateStatusCheck'
+      responses:
         '200':
-          description: The created or updated StudentStatusCheckups
-          content: 
-            application/json: 
-              schema: 
+          description: The created status check for the given student
+          content:
+            application/json:
+              schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/StudentStatusCheckup'
+                  $ref: '#/components/schemas/StatusCheck'
+        '400':
+          $ref: '#/components/responses/400'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '429':
+          $ref: '#/components/responses/429'
+        '500':
+          $ref: '#/components/responses/500'
+    patch:
+      tags:
+        - Student
+      summary: Update a student status check
+      description: Update status check for a given student
+      operationId: updateStatusCheck
+      parameters:
+        - name: student_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: status check to update
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/CreateStatusCheck'
+      responses:
+        '200':
+          description: The created or updated StudentStatusCheckups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StatusCheck'
         '400':
           $ref: '#/components/responses/400'
         '403':
@@ -6615,7 +6655,7 @@ paths:
       tags:
         - Student
       operationId: getStudentStatusCheckup
-      summary: Get all student status checkup for a given student
+      summary: Get all status check for a given student
       parameters:
         - name: student_id
           in: path
@@ -6624,11 +6664,13 @@ paths:
             type: string
       responses:
         '200':
-          description: All student status checkup asked by teachers
+          description: All status check asked by all teachers on a given student
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StudentStatusCheckup'
+                type: array
+                items: 
+                  $ref: '#/components/schemas/StatusCheck'
         '400':
           $ref: '#/components/responses/400'
         '403':
@@ -9066,36 +9108,45 @@ components:
       enum:
         - YEARLY
         - MONTHLY
-    StudentStatusCheckup_Status: 
+    StatusCheckResult: 
       type: string
       enum: 
         - PENDING
         - WITHDRAWN
         - ENROLLED
-    CrupdateStudentStatusCheckup: 
+    UpdateStatusCheck:
+      type: object
+      properties:
+        id:
+          type: string
+        description:
+          type: string
+        result:
+          $ref: '#/components/schemas/StatusCheckResult'
+    CreateStatusCheck:
       type: object 
       properties: 
         id: 
           type: string 
-        student_id: 
+        concerned_student_id:
           type: string 
-        teacher_id: 
+        requesting_teacher_id:
           type: string
         description:
           type: string
-    StudentStatusCheckup: 
+    StatusCheck:
       type: object 
       properties: 
         id:
           type: string
-        student:
+        concerned_student:
           $ref: '#/components/schemas/UserIdentifier'
-        teacher:
+        requesting_teacher:
           $ref: '#/components/schemas/UserIdentifier'
         description:
           type: string
-        status: 
-          $ref: '#/components/schemas/StudentStatusCheckup_Status'
+        result:
+          $ref: '#/components/schemas/StatusCheckResult'
         creation_datetime: 
           type: string
           format: date-time

--- a/doc/api.yml
+++ b/doc/api.yml
@@ -6571,46 +6571,6 @@ paths:
         '500':
           $ref: '#/components/responses/500'
   '/students/{student_id}/status-check':
-    post:
-      tags:
-        - Student
-      summary: Create a student status check
-      description: Create status check for a given student
-      operationId: createStatusCheck
-      parameters:
-        - name: student_id
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        description: The status checks to create on a given student
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/CreateStatusCheck'
-      responses:
-        '200':
-          description: The created status check for the given student
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/StatusCheck'
-        '400':
-          $ref: '#/components/responses/400'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '429':
-          $ref: '#/components/responses/429'
-        '500':
-          $ref: '#/components/responses/500'
     patch:
       tags:
         - Student
@@ -6629,12 +6589,49 @@ paths:
         content:
           application/json:
             schema:
+              $ref: '#/components/schemas/UpdateStatusCheck'
+      responses:
+        '200':
+          description: The created or updated status-checks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusCheck'
+        '400':
+          $ref: '#/components/responses/400'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '429':
+          $ref: '#/components/responses/429'
+        '500':
+          $ref: '#/components/responses/500'
+  '/students/{student_id}/status-checks':
+    post:
+      tags:
+        - Student
+      summary: Create a student status check
+      description: Create status check for a given student
+      operationId: createStatusChecks
+      parameters:
+        - name: student_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The status checks to create on a given student
+        required: true
+        content:
+          application/json:
+            schema:
               type: array
               items:
                 $ref: '#/components/schemas/CreateStatusCheck'
       responses:
         '200':
-          description: The created or updated StudentStatusCheckups
+          description: The created status checks for the given student
           content:
             application/json:
               schema:
@@ -6654,8 +6651,8 @@ paths:
     get:
       tags:
         - Student
-      operationId: getStudentStatusCheckup
-      summary: Get all status check for a given student
+      operationId: getStudentStatusChecks
+      summary: Get all status checks for a given student
       parameters:
         - name: student_id
           in: path
@@ -6664,7 +6661,7 @@ paths:
             type: string
       responses:
         '200':
-          description: All status check asked by all teachers on a given student
+          description: All status checks asked by all teachers on a given student
           content:
             application/json:
               schema:


### PR DESCRIPTION
It has been asked if we could have the list of all potential students who left the school. 

So to do this, instead of getting the missing record of everyone, we simply send a StudentStatusCheckup request to say that this student should be checked if he/she is still active. 

It is much more explicit than just saying : he's missing a lot => he must have quit. 