### PR TITLE
fix: get course result

### DIFF
--- a/src/main/java/school/hei/haapi/service/CourseResultService.java
+++ b/src/main/java/school/hei/haapi/service/CourseResultService.java
@@ -53,7 +53,7 @@ public class CourseResultService {
     return collectionUtils
         .filterDistinctByField(
             exams.stream()
-                .map(e -> student.findGroupAt(e.getExaminationDate()))
+                .map(exam -> student.findGroupAt(exam.getExaminationDate()))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .toList(),
@@ -66,44 +66,44 @@ public class CourseResultService {
   public List<CourseResult> getCourseResultsForLevelOfStudent(
       StudentLevel level, String studentId) {
     var student = userService.getById(studentId);
-    log.info("group flows :" + student.getGroupFlows());
-    var courseForSpecificLevel = courseService.getByStudentLevel(level);
-    var courseForSpecificStudent =
+    var coursesForSpecificLevel = courseService.getByStudentLevel(level);
+    log.info("Course for specific level : {}", coursesForSpecificLevel);
+    var coursesForSpecificStudent =
         collectionUtils.filterDistinctByField(
-            getCourseInStudentGroup(courseForSpecificLevel, student), Course::getId);
-    return courseForSpecificStudent.stream()
+            getCourseInStudentGroup(coursesForSpecificLevel, student), Course::getId);
+    return coursesForSpecificStudent.stream()
         .map(course -> computeCourseResult(course, student))
         .sorted(comparing(courseResult -> courseResult.getStatus().ordinal()))
         .toList();
   }
 
   @NotNull
-  private List<Course> getCourseInStudentGroup(List<Course> courseForSpecificLevel, User student) {
-    return courseForSpecificLevel.stream()
+  private List<Course> getCourseInStudentGroup(List<Course> coursesForSpecificLevel, User student) {
+    return coursesForSpecificLevel.stream()
         .map(Course::getCourseAssignments)
-        .filter(
-            ca -> {
-              var courseAssignmentGroupIds =
-                  ca.stream()
-                      .map(CourseAssignment::getGroups)
-                      .flatMap(e -> e.stream().map(Group::getId))
-                      .toList();
-              var caIds = ca.stream().map(CourseAssignment::getId).toList();
-              var studentGroupIds =
-                  student.getGroupFlows().stream()
-                      .map(groupFlow -> groupFlow.getGroup().getId())
-                      .toList();
-              var exams = examService.getExamsByCourseAssignmentIds(caIds);
-              if (exams.isEmpty()) {
-                return courseAssignmentGroupIds.stream().anyMatch(studentGroupIds::contains);
-              }
-
-              var studentExamGroupIds =
-                  findStudentGroupByExams(student, exams).stream().map(Group::getId).toList();
-              return courseAssignmentGroupIds.stream().anyMatch(studentExamGroupIds::contains);
-            })
-        .flatMap(e -> e.stream().map(CourseAssignment::getCourse))
+        .filter(courseAssignments -> isAssignedToTheGroup(courseAssignments, student))
+        .flatMap(courseAssignments -> courseAssignments.stream().map(CourseAssignment::getCourse))
         .toList();
+  }
+
+  private boolean isAssignedToTheGroup(List<CourseAssignment> courseAssignments, User student) {
+    var courseAssignmentGroupIds =
+        courseAssignments.stream()
+            .map(CourseAssignment::getGroups)
+            .flatMap(groups -> groups.stream().map(Group::getId))
+            .toList();
+    var courseAssignmentIds = courseAssignments.stream().map(CourseAssignment::getId).toList();
+    log.info("All student group flows : {}", student.getGroupFlows());
+    var studentGroupIds =
+        student.getGroupFlows().stream().map(groupFlow -> groupFlow.getGroup().getId()).toList();
+    var exams = examService.getExamsByCourseAssignmentIds(courseAssignmentIds);
+    if (exams.isEmpty()) {
+      return courseAssignmentGroupIds.stream().anyMatch(studentGroupIds::contains);
+    }
+
+    var studentExamGroupIds =
+        findStudentGroupByExams(student, exams).stream().map(Group::getId).toList();
+    return courseAssignmentGroupIds.stream().anyMatch(studentExamGroupIds::contains);
   }
 
   private CourseResult computeCourseResult(Course course, User student) {
@@ -145,24 +145,31 @@ public class CourseResultService {
   public BigDecimal obtainedCreditsOfCourseResults(List<CourseResult> courseResults) {
     return BigDecimal.valueOf(
         courseResults.stream()
-            .filter(c -> nonNull(c.getWeightedAverage()))
+            .filter(courseResult -> nonNull(courseResult.getWeightedAverage()))
             .mapToDouble(
-                c -> c.getWeightedAverage().doubleValue() >= 10 ? c.getCourse().getCredits() : 0.)
+                courseResult ->
+                    courseResult.getWeightedAverage().doubleValue() >= 10
+                        ? courseResult.getCourse().getCredits()
+                        : 0.)
             .sum());
   }
 
   public Optional<BigDecimal> weightedSumOfCourseResults(List<CourseResult> courseResults) {
     int sumCredits = getSumCredits(courseResults);
     var presentCourseResults =
-        courseResults.stream().filter(c -> nonNull(c.getWeightedAverage())).toList();
+        courseResults.stream()
+            .filter(courseResult -> nonNull(courseResult.getWeightedAverage()))
+            .toList();
 
     if (presentCourseResults.isEmpty()) return Optional.empty();
 
     return Optional.of(
         presentCourseResults.stream()
             .map(
-                c ->
-                    c.getWeightedAverage().multiply(BigDecimal.valueOf(c.getCourse().getCredits())))
+                courseResult ->
+                    courseResult
+                        .getWeightedAverage()
+                        .multiply(BigDecimal.valueOf(courseResult.getCourse().getCredits())))
             .reduce(ZERO, BigDecimal::add)
             .divide(BigDecimal.valueOf(sumCredits), DECIMAL128));
   }
@@ -192,7 +199,7 @@ public class CourseResultService {
 
     return obtainedCredits.compareTo(VALIDATED_YEAR_CREDIT) >= 0
         && courseResultsWeightedAverage
-            .map(avg -> avg.compareTo(VALIDATED_YEAR_AVERAGE) >= 0)
+            .map(average -> average.compareTo(VALIDATED_YEAR_AVERAGE) >= 0)
             .orElse(false);
   }
 

--- a/src/main/java/school/hei/haapi/service/CourseResultService.java
+++ b/src/main/java/school/hei/haapi/service/CourseResultService.java
@@ -1,22 +1,8 @@
 package school.hei.haapi.service;
 
-import static java.math.BigDecimal.TEN;
-import static java.math.BigDecimal.ZERO;
-import static java.math.MathContext.DECIMAL128;
-import static java.util.Comparator.comparing;
-import static java.util.Objects.nonNull;
-import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.INVALIDATED;
-import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.IN_PROGRESS;
-import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.NOT_STARTED;
-import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.VALIDATED;
-import static school.hei.haapi.model.Grade.weightedAverageOfGrades;
-
 import jakarta.transaction.Transactional;
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import school.hei.haapi.endpoint.rest.mapper.CourseMapper;
@@ -34,8 +20,25 @@ import school.hei.haapi.model.exception.ExamsCoefficientSumZero;
 import school.hei.haapi.repository.dao.GradeDao;
 import school.hei.haapi.service.utils.CollectionUtils;
 
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.math.BigDecimal.TEN;
+import static java.math.BigDecimal.ZERO;
+import static java.math.MathContext.DECIMAL128;
+import static java.util.Comparator.comparing;
+import static java.util.Objects.nonNull;
+import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.INVALIDATED;
+import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.IN_PROGRESS;
+import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.NOT_STARTED;
+import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.VALIDATED;
+import static school.hei.haapi.model.Grade.weightedAverageOfGrades;
+
 @Service
 @AllArgsConstructor
+@Slf4j
 public class CourseResultService {
   private final CourseService courseService;
   private final GradeDao gradeDao;
@@ -64,6 +67,7 @@ public class CourseResultService {
   public List<CourseResult> getCourseResultsForLevelOfStudent(
       StudentLevel level, String studentId) {
     var student = userService.getById(studentId);
+    log.info("group flows :" + student.getGroupFlows());
     var courseForSpecificLevel = courseService.getByStudentLevel(level);
     var courseForSpecificStudent =
         collectionUtils.filterDistinctByField(
@@ -86,9 +90,13 @@ public class CourseResultService {
                       .flatMap(e -> e.stream().map(Group::getId))
                       .toList();
               var caIds = ca.stream().map(CourseAssignment::getId).toList();
+              var studentGroupIds =
+                  student.getGroupFlows().stream()
+                      .map(groupFlow -> groupFlow.getGroup().getId())
+                      .toList();
               var exams = examService.getExamsByCourseAssignmentIds(caIds);
               if (exams.isEmpty()) {
-                return true;
+                return courseAssignmentGroupIds.stream().anyMatch(studentGroupIds::contains);
               }
 
               var studentExamGroupIds =

--- a/src/main/java/school/hei/haapi/service/CourseResultService.java
+++ b/src/main/java/school/hei/haapi/service/CourseResultService.java
@@ -1,6 +1,21 @@
 package school.hei.haapi.service;
 
+import static java.math.BigDecimal.TEN;
+import static java.math.BigDecimal.ZERO;
+import static java.math.MathContext.DECIMAL128;
+import static java.util.Comparator.comparing;
+import static java.util.Objects.nonNull;
+import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.INVALIDATED;
+import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.IN_PROGRESS;
+import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.NOT_STARTED;
+import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.VALIDATED;
+import static school.hei.haapi.model.Grade.weightedAverageOfGrades;
+
 import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -19,22 +34,6 @@ import school.hei.haapi.model.exception.CoursesCreditSumZero;
 import school.hei.haapi.model.exception.ExamsCoefficientSumZero;
 import school.hei.haapi.repository.dao.GradeDao;
 import school.hei.haapi.service.utils.CollectionUtils;
-
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import static java.math.BigDecimal.TEN;
-import static java.math.BigDecimal.ZERO;
-import static java.math.MathContext.DECIMAL128;
-import static java.util.Comparator.comparing;
-import static java.util.Objects.nonNull;
-import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.INVALIDATED;
-import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.IN_PROGRESS;
-import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.NOT_STARTED;
-import static school.hei.haapi.endpoint.rest.model.ResultOverviewStatus.VALIDATED;
-import static school.hei.haapi.model.Grade.weightedAverageOfGrades;
 
 @Service
 @AllArgsConstructor

--- a/src/main/java/school/hei/haapi/service/CourseResultService.java
+++ b/src/main/java/school/hei/haapi/service/CourseResultService.java
@@ -81,12 +81,13 @@ public class CourseResultService {
   private List<Course> getCourseInStudentGroup(List<Course> coursesForSpecificLevel, User student) {
     return coursesForSpecificLevel.stream()
         .map(Course::getCourseAssignments)
-        .filter(courseAssignments -> isAssignedToTheGroup(courseAssignments, student))
+        .filter(courseAssignments -> studentGroupIsAssignedToCourse(courseAssignments, student))
         .flatMap(courseAssignments -> courseAssignments.stream().map(CourseAssignment::getCourse))
         .toList();
   }
 
-  private boolean isAssignedToTheGroup(List<CourseAssignment> courseAssignments, User student) {
+  private boolean studentGroupIsAssignedToCourse(
+      List<CourseAssignment> courseAssignments, User student) {
     var courseAssignmentGroupIds =
         courseAssignments.stream()
             .map(CourseAssignment::getGroups)

--- a/src/main/java/school/hei/haapi/service/UserService.java
+++ b/src/main/java/school/hei/haapi/service/UserService.java
@@ -130,6 +130,7 @@ public class UserService {
     return userToRefresh;
   }
 
+  @Transactional
   public User getById(String userId) {
     return userRepository
         .findById(userId)

--- a/src/test/java/school/hei/haapi/integration/StudentRetakeExamListIT.java
+++ b/src/test/java/school/hei/haapi/integration/StudentRetakeExamListIT.java
@@ -49,7 +49,7 @@ public class StudentRetakeExamListIT extends FacadeITMockedThirdParties {
   void should_be_see_all_exams_with_all_status() throws ApiException {
     var api = new GradesApi(anApiClient(MANAGER1_TOKEN));
     var results = api.getListStudentRetakeExams(STUDENT1_ID, null).size();
-    var expected = 3;
+    var expected = 2;
     assertEquals(expected, results);
   }
 }

--- a/src/test/java/school/hei/haapi/service/GradeResultServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/GradeResultServiceTest.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import school.hei.haapi.endpoint.event.EventProducer;
 import school.hei.haapi.endpoint.event.model.YearlyResultTranscriptGeneration;
@@ -346,6 +345,10 @@ class GradeResultServiceTest {
     return GroupFlow.builder().group(group()).build();
   }
 
+  private static User student1WithGroupFlow() {
+    return User.builder().id(STUDENT1_ID).groupFlows(List.of(groupFlow())).build();
+  }
+
   private static Course mgt1Course() {
     return mockCourse(
         MGT1_COURSE_ID, MGT1_COURSE_CODE, MGT1_COURSE_NAME, 8, mgt1CourseAssignment(), L1);
@@ -403,7 +406,9 @@ class GradeResultServiceTest {
     when(student1.getRef()).thenReturn(STUDENT1_REF);
     when(student1.getSpecializationFieldString()).thenReturn(STUDENT1_SPECIALIZATION_FIELD_STRING);
     when(student1.findCurrentGroup()).thenReturn(Optional.of(group()));
+    doReturn(List.of(groupFlow())).when(student1).getGroupFlows();
     doReturn(List.of(groupFlow())).when(student2).getGroupFlows();
+    doReturn(List.of(groupFlow())).when(student1).getGroupFlows();
 
     // Mock student Ids
     when(student2.getId()).thenReturn(STUDENT2_ID);
@@ -639,7 +644,6 @@ class GradeResultServiceTest {
   }
 
   @Test
-  @Disabled
   void yearly_result_with_course_credits_sum_zero_ko() {
     when(gradeDao.getStudentGradesByCourseId(MGT1_COURSE_ID, STUDENT1_ID))
         .thenReturn(List.of(student1Mgt1Grade()));

--- a/src/test/java/school/hei/haapi/service/GradeResultServiceTest.java
+++ b/src/test/java/school/hei/haapi/service/GradeResultServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.only;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import school.hei.haapi.endpoint.event.EventProducer;
 import school.hei.haapi.endpoint.event.model.YearlyResultTranscriptGeneration;
@@ -57,6 +59,7 @@ import school.hei.haapi.model.Exam;
 import school.hei.haapi.model.FileInfo;
 import school.hei.haapi.model.Grade;
 import school.hei.haapi.model.Group;
+import school.hei.haapi.model.GroupFlow;
 import school.hei.haapi.model.Promotion;
 import school.hei.haapi.model.User;
 import school.hei.haapi.model.YearlyResultGenerationRequest;
@@ -339,6 +342,10 @@ class GradeResultServiceTest {
   private static final String BAD1_COURSE_CODE = "bad course";
   private static final String BAD1_COURSE_NAME = "Bad course";
 
+  private static GroupFlow groupFlow() {
+    return GroupFlow.builder().group(group()).build();
+  }
+
   private static Course mgt1Course() {
     return mockCourse(
         MGT1_COURSE_ID, MGT1_COURSE_CODE, MGT1_COURSE_NAME, 8, mgt1CourseAssignment(), L1);
@@ -371,7 +378,7 @@ class GradeResultServiceTest {
 
   private static Course secu3Course() {
     return mockCourse(
-        SECU3_COURSE_ID, SECU3_COURSE_CODE, SECU3_COURSE_NAME, 8, secu3CourseAssignment(), L1);
+        SECU3_COURSE_ID, SECU3_COURSE_CODE, SECU3_COURSE_NAME, 8, secu3CourseAssignment(), M1);
   }
 
   private static Course l2Course() {
@@ -396,6 +403,7 @@ class GradeResultServiceTest {
     when(student1.getRef()).thenReturn(STUDENT1_REF);
     when(student1.getSpecializationFieldString()).thenReturn(STUDENT1_SPECIALIZATION_FIELD_STRING);
     when(student1.findCurrentGroup()).thenReturn(Optional.of(group()));
+    doReturn(List.of(groupFlow())).when(student2).getGroupFlows();
 
     // Mock student Ids
     when(student2.getId()).thenReturn(STUDENT2_ID);
@@ -631,6 +639,7 @@ class GradeResultServiceTest {
   }
 
   @Test
+  @Disabled
   void yearly_result_with_course_credits_sum_zero_ko() {
     when(gradeDao.getStudentGradesByCourseId(MGT1_COURSE_ID, STUDENT1_ID))
         .thenReturn(List.of(student1Mgt1Grade()));


### PR DESCRIPTION
Fix getCourseResultsForLevelOfStudent

Before: 
 . The method returned all courses, even if the student's group was not assigned to the course.

After: 
 . The method returns only the courses that:

       - are assigned to the student's group, and
       - have at least one exam.