### PR TITLE
Feat: add fees only mode filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ and implements it in Java.
 [Releases](https://github.com/hei-school/hei-admin-api/releases) are published [here](https://gallery.ecr.aws/q6i6y5o4/hei-admin-api) as Docker images. Feel free to use them.
 
 We welcome [contributions](https://github.com/hei-school/hei-admin-api/blob/dev/CONTRIBUTING.md).
+
+## FEES_ONLY mode
+
+Set the environment variable `FEES_ONLY=true` to restrict the API to a read-only subset of endpoints.
+In this mode, only requests targeting the following URI prefixes are allowed:
+
+| Prefix | Description |
+|--------|-------------|
+| `/fees` | Fee management |
+| `/students` | Student management |
+| `/whoami` | Current user identity |
+| `/ping` | Liveness check |
+| `/authentication` | Authentication |
+| `/health` | Health checks |
+| `/mpbs` | Mobile Payment by SMS |
+
+All other endpoints return **HTTP 403 Forbidden** with the message
+`"This endpoint is disabled in FEES_ONLY mode"`.
+
+When `FEES_ONLY` is unset or `false`, the API behaves normally.

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -16,11 +17,7 @@ public class FeesOnlyFilter extends OncePerRequestFilter {
 
   private final boolean feesOnly;
 
-  public FeesOnlyFilter() {
-    this("true".equalsIgnoreCase(System.getenv("FEES_ONLY")));
-  }
-
-  public FeesOnlyFilter(boolean feesOnly) {
+  public FeesOnlyFilter(@Value("${FEES_ONLY:false}") boolean feesOnly) {
     this.feesOnly = feesOnly;
   }
 

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
@@ -37,8 +37,8 @@ public class FeesOnlyFilter extends OncePerRequestFilter {
       return;
     }
 
-    String uri = request.getRequestURI();
-    boolean allowed = ALLOWED_PREFIXES.stream().anyMatch(uri::startsWith);
+    var uri = request.getRequestURI();
+    var allowed = ALLOWED_PREFIXES.stream().anyMatch(uri::startsWith);
 
     if (!allowed) {
       log.info("FEES_ONLY mode: blocked request to {}", uri);

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
@@ -1,0 +1,55 @@
+package school.hei.haapi.endpoint.rest.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Restricts the API surface to a minimal set of prefixes when the application is started in
+ * "fees only" mode. Intended as a kill-switch for incidents: keep payments and the student
+ * read paths reachable while every other feature is short-circuited with HTTP 403.
+ *
+ * <p>Activation is controlled by the {@code FEES_ONLY} environment variable / property
+ * (default {@code false}). When the flag is off this filter is a no-op.
+ */
+@Component
+@Slf4j
+public class FeesOnlyFilter extends OncePerRequestFilter {
+
+  @Value("${FEES_ONLY:false}")
+  private boolean feesOnly;
+
+  private static final List<String> ALLOWED_PREFIXES =
+      List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    if (!feesOnly) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String uri = request.getRequestURI();
+    boolean allowed = ALLOWED_PREFIXES.stream().anyMatch(uri::startsWith);
+
+    if (!allowed) {
+      log.info("FEES_ONLY mode: blocked request to {}", uri);
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      response.setContentType("application/json");
+      response.getWriter().write("{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}");
+      return;
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
@@ -15,38 +15,38 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class FeesOnlyFilter extends OncePerRequestFilter {
 
-    private final boolean feesOnly;
+  private final boolean feesOnly;
 
-    public FeesOnlyFilter(@Value("${FEES_ONLY:false}") boolean feesOnly) {
-        this.feesOnly = feesOnly;
+  public FeesOnlyFilter(@Value("${FEES_ONLY:false}") boolean feesOnly) {
+    this.feesOnly = feesOnly;
+  }
+
+  private static final List<String> ALLOWED_PREFIXES =
+      List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
+
+  @Override
+  public void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    if (!feesOnly) {
+      filterChain.doFilter(request, response);
+      return;
     }
 
-    private static final List<String> ALLOWED_PREFIXES =
-            List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
+    var uri = request.getRequestURI();
+    var allowed =
+        ALLOWED_PREFIXES.stream()
+            .anyMatch(prefix -> uri.equals(prefix) || uri.startsWith(prefix + "/"));
 
-    @Override
-    public void doFilterInternal(
-            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
-
-        if (!feesOnly) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        var uri = request.getRequestURI();
-        var allowed =
-                ALLOWED_PREFIXES.stream()
-                        .anyMatch(prefix -> uri.equals(prefix) || uri.startsWith(prefix + "/"));
-
-        if (!allowed) {
-            log.info("FEES_ONLY mode: blocked request to {}", uri);
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-            response.setContentType("application/json");
-            response.getWriter().write("{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}");
-            return;
-        }
-
-        filterChain.doFilter(request, response);
+    if (!allowed) {
+      log.info("FEES_ONLY mode: blocked request to {}", uri);
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      response.setContentType("application/json");
+      response.getWriter().write("{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}");
+      return;
     }
+
+    filterChain.doFilter(request, response);
+  }
 }

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-
 @Component
 @Slf4j
 public class FeesOnlyFilter extends OncePerRequestFilter {

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
@@ -7,30 +7,29 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-/**
- * Restricts the API surface to a minimal set of prefixes when the application is started in
- * "fees only" mode. Intended as a kill-switch for incidents: keep payments and the student
- * read paths reachable while every other feature is short-circuited with HTTP 403.
- *
- * <p>Activation is controlled by the {@code FEES_ONLY} environment variable / property
- * (default {@code false}). When the flag is off this filter is a no-op.
- */
+
 @Component
 @Slf4j
 public class FeesOnlyFilter extends OncePerRequestFilter {
 
-  @Value("${FEES_ONLY:false}")
-  private boolean feesOnly;
+  private final boolean feesOnly;
+
+  public FeesOnlyFilter() {
+    this("true".equalsIgnoreCase(System.getenv("FEES_ONLY")));
+  }
+
+  public FeesOnlyFilter(boolean feesOnly) {
+    this.feesOnly = feesOnly;
+  }
 
   private static final List<String> ALLOWED_PREFIXES =
       List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
 
   @Override
-  protected void doFilterInternal(
+  public void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
 

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/FeesOnlyFilter.java
@@ -15,36 +15,38 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 public class FeesOnlyFilter extends OncePerRequestFilter {
 
-  private final boolean feesOnly;
+    private final boolean feesOnly;
 
-  public FeesOnlyFilter(@Value("${FEES_ONLY:false}") boolean feesOnly) {
-    this.feesOnly = feesOnly;
-  }
-
-  private static final List<String> ALLOWED_PREFIXES =
-      List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
-
-  @Override
-  public void doFilterInternal(
-      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-      throws ServletException, IOException {
-
-    if (!feesOnly) {
-      filterChain.doFilter(request, response);
-      return;
+    public FeesOnlyFilter(@Value("${FEES_ONLY:false}") boolean feesOnly) {
+        this.feesOnly = feesOnly;
     }
 
-    var uri = request.getRequestURI();
-    var allowed = ALLOWED_PREFIXES.stream().anyMatch(uri::startsWith);
+    private static final List<String> ALLOWED_PREFIXES =
+            List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
 
-    if (!allowed) {
-      log.info("FEES_ONLY mode: blocked request to {}", uri);
-      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-      response.setContentType("application/json");
-      response.getWriter().write("{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}");
-      return;
+    @Override
+    public void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (!feesOnly) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        var uri = request.getRequestURI();
+        var allowed =
+                ALLOWED_PREFIXES.stream()
+                        .anyMatch(prefix -> uri.equals(prefix) || uri.startsWith(prefix + "/"));
+
+        if (!allowed) {
+            log.info("FEES_ONLY mode: blocked request to {}", uri);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
     }
-
-    filterChain.doFilter(request, response);
-  }
 }

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
@@ -91,9 +91,8 @@ public class SecurityConf {
 
         // authenticate
         .authenticationProvider(authProvider)
-            .addFilterBefore(feesOnlyFilter, AnonymousAuthenticationFilter.class)
-
-            .addFilterBefore(
+        .addFilterBefore(feesOnlyFilter, AnonymousAuthenticationFilter.class)
+        .addFilterBefore(
             bearerFilter(
                 new OrRequestMatcher(
                     antMatcher(GET, "/whoami"),
@@ -1125,7 +1124,6 @@ public class SecurityConf {
                     .authenticated()
                     .requestMatchers("/**")
                     .denyAll())
-
         .cors(AbstractHttpConfigurer::disable)
         .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
@@ -80,10 +80,6 @@ public class SecurityConf {
             exceptionHandlingConfigurer ->
                 exceptionHandlingConfigurer
                     .authenticationEntryPoint(
-                        // note(spring-exception)
-                        // https://stackoverflow.com/questions/59417122/how-to-handle-usernamenotfoundexception-spring-security
-                        // issues like when a user tries to access a resource
-                        // without appropriate authentication elements
                         (req, res, e) ->
                             exceptionResolver.resolveException(
                                 req, res, null, forbiddenWithRemoteInfo(req)))
@@ -1130,10 +1126,6 @@ public class SecurityConf {
                     .requestMatchers("/**")
                     .denyAll())
 
-        // disable superfluous protections
-        // Eg if all clients are non-browser then no csrf
-        // https://docs.spring.io/spring-security/site/docs/3.2.0.CI-SNAPSHOT/reference/html/csrf.html,
-        // Sec 13.3
         .cors(AbstractHttpConfigurer::disable)
         .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
@@ -1158,11 +1150,6 @@ public class SecurityConf {
         (httpServletRequest, httpServletResponse, authentication) -> {});
     bearerFilter.setAuthenticationFailureHandler(
         (req, res, e) ->
-            // note(spring-exception)
-            // issues like when a user is not found(i.e. UsernameNotFoundException)
-            // or other exceptions thrown inside authentication provider.
-            // In fact, this handles other authentication exceptions that are
-            // not handled by AccessDeniedException and AuthenticationEntryPoint
             exceptionResolver.resolveException(req, res, null, forbiddenWithRemoteInfo(req)));
     return bearerFilter;
   }

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
@@ -80,6 +80,10 @@ public class SecurityConf {
             exceptionHandlingConfigurer ->
                 exceptionHandlingConfigurer
                     .authenticationEntryPoint(
+                        // note(spring-exception)
+                        // https://stackoverflow.com/questions/59417122/how-to-handle-usernamenotfoundexception-spring-security
+                        // issues like when a user tries to access a resource
+                        // without appropriate authentication elements
                         (req, res, e) ->
                             exceptionResolver.resolveException(
                                 req, res, null, forbiddenWithRemoteInfo(req)))
@@ -1124,6 +1128,10 @@ public class SecurityConf {
                     .authenticated()
                     .requestMatchers("/**")
                     .denyAll())
+        // disable superfluous protections
+        // Eg if all clients are non-browser then no csrf
+        // https://docs.spring.io/spring-security/site/docs/3.2.0.CI-SNAPSHOT/reference/html/csrf.html,
+        // Sec 13.3
         .cors(AbstractHttpConfigurer::disable)
         .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
@@ -1148,6 +1156,11 @@ public class SecurityConf {
         (httpServletRequest, httpServletResponse, authentication) -> {});
     bearerFilter.setAuthenticationFailureHandler(
         (req, res, e) ->
+            // note(spring-exception)
+            // issues like when a user is not found(i.e. UsernameNotFoundException)
+            // or other exceptions thrown inside authentication provider.
+            // In fact, this handles other authentication exceptions that are
+            // not handled by AccessDeniedException and AuthenticationEntryPoint
             exceptionResolver.resolveException(req, res, null, forbiddenWithRemoteInfo(req)));
     return bearerFilter;
   }

--- a/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
+++ b/src/main/java/school/hei/haapi/endpoint/rest/security/SecurityConf.java
@@ -47,6 +47,7 @@ public class SecurityConf {
   private final AbstractUserDetailsAuthenticationProvider authProvider;
   private final HandlerExceptionResolver exceptionResolver;
   private final CorRepository corRepository;
+  private final FeesOnlyFilter feesOnlyFilter;
 
   public SecurityConf(
       CasdoorAuthProvider authProvider,
@@ -54,12 +55,14 @@ public class SecurityConf {
       @Qualifier("handlerExceptionResolver") HandlerExceptionResolver exceptionResolver,
       CourseAssignmentService courseAssignmentService,
       MonitoringStudentService monitoringStudentService,
-      CorRepository corRepository) {
+      CorRepository corRepository,
+      FeesOnlyFilter feesOnlyFilter) {
     this.authProvider = authProvider;
     this.exceptionResolver = exceptionResolver;
     this.courseAssignmentService = courseAssignmentService;
     this.monitoringStudentService = monitoringStudentService;
     this.corRepository = corRepository;
+    this.feesOnlyFilter = feesOnlyFilter;
   }
 
   @Bean
@@ -92,7 +95,9 @@ public class SecurityConf {
 
         // authenticate
         .authenticationProvider(authProvider)
-        .addFilterBefore(
+            .addFilterBefore(feesOnlyFilter, AnonymousAuthenticationFilter.class)
+
+            .addFilterBefore(
             bearerFilter(
                 new OrRequestMatcher(
                     antMatcher(GET, "/whoami"),

--- a/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
+++ b/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
@@ -1,0 +1,99 @@
+package school.hei.haapi.unit;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import school.hei.haapi.endpoint.rest.security.FeesOnlyFilter;
+
+@ExtendWith(MockitoExtension.class)
+class FeesOnlyFilterTest {
+
+  @Mock private FilterChain filterChain;
+
+  @Test
+  void fees_only_inactive_all_requests_pass() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/teachers");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(200, response.getStatus());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void fees_only_active_allows_configured_prefixes() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+    List<String> allowedPrefixes =
+        List.of(
+            "/fees",
+            "/students",
+            "/whoami",
+            "/ping",
+            "/authentication",
+            "/health",
+            "/mpbs");
+
+    for (String prefix : allowedPrefixes) {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setRequestURI(prefix);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertEquals(
+          200, response.getStatus(), "URI " + prefix + " should be allowed in FEES_ONLY mode");
+    }
+  }
+
+  @Test
+  void fees_only_active_blocks_other_uris() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+    List<String> blockedUris =
+        List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
+
+    for (String uri : blockedUris) {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setRequestURI(uri);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertEquals(SC_FORBIDDEN, response.getStatus(), "URI " + uri + " should be blocked");
+      assertEquals(
+          "{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}",
+          response.getContentAsString());
+    }
+  }
+
+  @Test
+  void fees_only_active_allows_subpaths_of_allowed_prefixes()
+      throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/students/student1_id/fees/fee1_id/payments");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(200, response.getStatus());
+    verify(filterChain).doFilter(request, response);
+  }
+}

--- a/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
+++ b/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
@@ -20,207 +20,212 @@ import school.hei.haapi.endpoint.rest.security.FeesOnlyFilter;
 @ExtendWith(MockitoExtension.class)
 class FeesOnlyFilterTest {
 
-    @Mock private FilterChain filterChain;
+  @Mock private FilterChain filterChain;
 
-    @Test
-    void fees_only_inactive_all_requests_pass() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+  @Test
+  void fees_only_inactive_all_requests_pass() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(false);
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/teachers");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/teachers");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-        filter.doFilterInternal(request, response, filterChain);
+    filter.doFilterInternal(request, response, filterChain);
 
-        assertEquals(200, response.getStatus());
-        verify(filterChain).doFilter(request, response);
+    assertEquals(200, response.getStatus());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void fees_only_active_allows_configured_prefixes() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+    List<String> allowedPrefixes =
+        List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
+
+    for (String prefix : allowedPrefixes) {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setRequestURI(prefix);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertEquals(
+          200, response.getStatus(), "URI " + prefix + " should be allowed in FEES_ONLY mode");
     }
+  }
 
-    @Test
-    void fees_only_active_allows_configured_prefixes() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+  @Test
+  void fees_only_active_blocks_other_uris() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-        List<String> allowedPrefixes =
-                List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
+    List<String> blockedUris =
+        List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
 
-        for (String prefix : allowedPrefixes) {
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.setRequestURI(prefix);
-            MockHttpServletResponse response = new MockHttpServletResponse();
+    for (String uri : blockedUris) {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setRequestURI(uri);
+      MockHttpServletResponse response = new MockHttpServletResponse();
 
-            filter.doFilterInternal(request, response, filterChain);
+      filter.doFilterInternal(request, response, filterChain);
 
-            assertEquals(
-                    200, response.getStatus(), "URI " + prefix + " should be allowed in FEES_ONLY mode");
-        }
+      assertEquals(SC_FORBIDDEN, response.getStatus(), "URI " + uri + " should be blocked");
+      assertEquals(
+          "{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}",
+          response.getContentAsString());
     }
+  }
 
-    @Test
-    void fees_only_active_blocks_other_uris() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+  @Test
+  void fees_only_active_allows_subpaths_of_allowed_prefixes() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-        List<String> blockedUris =
-                List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/students/student1_id/fees/fee1_id/payments");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-        for (String uri : blockedUris) {
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.setRequestURI(uri);
-            MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilterInternal(request, response, filterChain);
 
-            filter.doFilterInternal(request, response, filterChain);
+    assertEquals(200, response.getStatus());
+    verify(filterChain).doFilter(request, response);
+  }
 
-            assertEquals(SC_FORBIDDEN, response.getStatus(), "URI " + uri + " should be blocked");
-            assertEquals(
-                    "{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}",
-                    response.getContentAsString());
-        }
+  @Test
+  void fees_only_inactive_allows_previously_blocked_uris() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+
+    List<String> uris =
+        List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
+
+    for (String uri : uris) {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setRequestURI(uri);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilterInternal(request, response, filterChain);
+
+      assertEquals(
+          200, response.getStatus(), "URI " + uri + " should pass when FEES_ONLY is inactive");
     }
+  }
 
-    @Test
-    void fees_only_active_allows_subpaths_of_allowed_prefixes() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+  @Test
+  void fees_only_inactive_does_not_write_forbidden_body() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(false);
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/students/student1_id/fees/fee1_id/payments");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/exams");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-        filter.doFilterInternal(request, response, filterChain);
+    filter.doFilterInternal(request, response, filterChain);
 
-        assertEquals(200, response.getStatus());
-        verify(filterChain).doFilter(request, response);
+    assertEquals("", response.getContentAsString());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void fees_only_inactive_calls_filter_chain_for_every_request()
+      throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+
+    List<String> uris = List.of("/fees", "/students", "/teachers", "/anything/goes/here");
+
+    for (String uri : uris) {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.setRequestURI(uri);
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilterInternal(request, response, filterChain);
+
+      verify(filterChain).doFilter(request, response);
     }
+  }
 
-    @Test
-    void fees_only_inactive_allows_previously_blocked_uris() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+  @Test
+  void fees_only_inactive_allows_root_and_empty_like_uris() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(false);
 
-        List<String> uris =
-                List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-        for (String uri : uris) {
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.setRequestURI(uri);
-            MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilterInternal(request, response, filterChain);
 
-            filter.doFilterInternal(request, response, filterChain);
+    assertEquals(200, response.getStatus());
+    verify(filterChain).doFilter(request, response);
+  }
 
-            assertEquals(200, response.getStatus(), "URI " + uri + " should pass when FEES_ONLY is inactive");
-        }
-    }
+  @Test
+  void fees_only_active_does_not_call_filter_chain_when_blocked()
+      throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-    @Test
-    void fees_only_inactive_does_not_write_forbidden_body() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/teachers");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/exams");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilterInternal(request, response, filterChain);
 
-        filter.doFilterInternal(request, response, filterChain);
+    verify(filterChain, never()).doFilter(request, response);
+  }
 
-        assertEquals("", response.getContentAsString());
-        verify(filterChain).doFilter(request, response);
-    }
+  @Test
+  void fees_only_active_blocked_response_has_json_content_type()
+      throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-    @Test
-    void fees_only_inactive_calls_filter_chain_for_every_request() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/teachers");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-        List<String> uris = List.of("/fees", "/students", "/teachers", "/anything/goes/here");
+    filter.doFilterInternal(request, response, filterChain);
 
-        for (String uri : uris) {
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.setRequestURI(uri);
-            MockHttpServletResponse response = new MockHttpServletResponse();
+    assertEquals("application/json", response.getContentType());
+  }
 
-            filter.doFilterInternal(request, response, filterChain);
+  @Test
+  void fees_only_active_blocks_uris_that_merely_start_with_allowed_prefix()
+      throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-            verify(filterChain).doFilter(request, response);
-        }
-    }
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/feesnotreal");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    @Test
-    void fees_only_inactive_allows_root_and_empty_like_uris() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    filter.doFilterInternal(request, response, filterChain);
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    assertEquals(
+        SC_FORBIDDEN,
+        response.getStatus(),
+        "'/feesnotreal' should not be treated as a valid subpath of '/fees'");
+  }
 
-        filter.doFilterInternal(request, response, filterChain);
+  @Test
+  void fees_only_active_is_case_sensitive_on_prefixes() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-        assertEquals(200, response.getStatus());
-        verify(filterChain).doFilter(request, response);
-    }
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/FEES/invoice1");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    @Test
-    void fees_only_active_does_not_call_filter_chain_when_blocked() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    filter.doFilterInternal(request, response, filterChain);
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/teachers");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+    assertEquals(
+        SC_FORBIDDEN,
+        response.getStatus(),
+        "startsWith() is case sensitive: '/FEES' does not match the '/fees' prefix");
+  }
 
-        filter.doFilterInternal(request, response, filterChain);
+  @Test
+  void fees_only_active_blocks_empty_uri() throws ServletException, IOException {
+    FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-        verify(filterChain, never()).doFilter(request, response);
-    }
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    @Test
-    void fees_only_active_blocked_response_has_json_content_type() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    filter.doFilterInternal(request, response, filterChain);
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/teachers");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        filter.doFilterInternal(request, response, filterChain);
-
-        assertEquals("application/json", response.getContentType());
-    }
-
-    @Test
-    void fees_only_active_blocks_uris_that_merely_start_with_allowed_prefix() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(true);
-
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/feesnotreal");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        filter.doFilterInternal(request, response, filterChain);
-
-        assertEquals(
-                SC_FORBIDDEN,
-                response.getStatus(),
-                "'/feesnotreal' should not be treated as a valid subpath of '/fees'");
-    }
-
-    @Test
-    void fees_only_active_is_case_sensitive_on_prefixes() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(true);
-
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("/FEES/invoice1");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        filter.doFilterInternal(request, response, filterChain);
-
-        assertEquals(
-                SC_FORBIDDEN,
-                response.getStatus(),
-                "startsWith() is case sensitive: '/FEES' does not match the '/fees' prefix");
-    }
-
-    @Test
-    void fees_only_active_blocks_empty_uri() throws ServletException, IOException {
-        FeesOnlyFilter filter = new FeesOnlyFilter(true);
-
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        filter.doFilterInternal(request, response, filterChain);
-
-        assertEquals(SC_FORBIDDEN, response.getStatus());
-    }
+    assertEquals(SC_FORBIDDEN, response.getStatus());
+  }
 }

--- a/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
+++ b/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
@@ -24,11 +24,11 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_inactive_all_requests_pass() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    var filter = new FeesOnlyFilter(false);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("/teachers");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 
@@ -38,15 +38,15 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_active_allows_configured_prefixes() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    var filter = new FeesOnlyFilter(true);
 
-    List<String> allowedPrefixes =
+    var allowedPrefixes =
         List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
 
-    for (String prefix : allowedPrefixes) {
-      MockHttpServletRequest request = new MockHttpServletRequest();
+    for (var prefix : allowedPrefixes) {
+      var request = new MockHttpServletRequest();
       request.setRequestURI(prefix);
-      MockHttpServletResponse response = new MockHttpServletResponse();
+      var response = new MockHttpServletResponse();
 
       filter.doFilterInternal(request, response, filterChain);
 
@@ -57,15 +57,14 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_active_blocks_other_uris() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    var filter = new FeesOnlyFilter(true);
 
-    List<String> blockedUris =
-        List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
+    var blockedUris = List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
 
-    for (String uri : blockedUris) {
-      MockHttpServletRequest request = new MockHttpServletRequest();
+    for (var uri : blockedUris) {
+      var request = new MockHttpServletRequest();
       request.setRequestURI(uri);
-      MockHttpServletResponse response = new MockHttpServletResponse();
+      var response = new MockHttpServletResponse();
 
       filter.doFilterInternal(request, response, filterChain);
 
@@ -78,11 +77,11 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_active_allows_subpaths_of_allowed_prefixes() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    var filter = new FeesOnlyFilter(true);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("/students/student1_id/fees/fee1_id/payments");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 
@@ -92,15 +91,14 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_inactive_allows_previously_blocked_uris() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    var filter = new FeesOnlyFilter(false);
 
-    List<String> uris =
-        List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
+    var uris = List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
 
-    for (String uri : uris) {
-      MockHttpServletRequest request = new MockHttpServletRequest();
+    for (var uri : uris) {
+      var request = new MockHttpServletRequest();
       request.setRequestURI(uri);
-      MockHttpServletResponse response = new MockHttpServletResponse();
+      var response = new MockHttpServletResponse();
 
       filter.doFilterInternal(request, response, filterChain);
 
@@ -111,11 +109,11 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_inactive_does_not_write_forbidden_body() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    var filter = new FeesOnlyFilter(false);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("/exams");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 
@@ -126,14 +124,14 @@ class FeesOnlyFilterTest {
   @Test
   void fees_only_inactive_calls_filter_chain_for_every_request()
       throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    var filter = new FeesOnlyFilter(false);
 
-    List<String> uris = List.of("/fees", "/students", "/teachers", "/anything/goes/here");
+    var uris = List.of("/fees", "/students", "/teachers", "/anything/goes/here");
 
-    for (String uri : uris) {
-      MockHttpServletRequest request = new MockHttpServletRequest();
+    for (var uri : uris) {
+      var request = new MockHttpServletRequest();
       request.setRequestURI(uri);
-      MockHttpServletResponse response = new MockHttpServletResponse();
+      var response = new MockHttpServletResponse();
 
       filter.doFilterInternal(request, response, filterChain);
 
@@ -143,11 +141,11 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_inactive_allows_root_and_empty_like_uris() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    var filter = new FeesOnlyFilter(false);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("/");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 
@@ -158,11 +156,11 @@ class FeesOnlyFilterTest {
   @Test
   void fees_only_active_does_not_call_filter_chain_when_blocked()
       throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    var filter = new FeesOnlyFilter(true);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("/teachers");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 
@@ -172,11 +170,11 @@ class FeesOnlyFilterTest {
   @Test
   void fees_only_active_blocked_response_has_json_content_type()
       throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    var filter = new FeesOnlyFilter(true);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("/teachers");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 
@@ -186,11 +184,11 @@ class FeesOnlyFilterTest {
   @Test
   void fees_only_active_blocks_uris_that_merely_start_with_allowed_prefix()
       throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    var filter = new FeesOnlyFilter(true);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("/feesnotreal");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 
@@ -202,11 +200,11 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_active_is_case_sensitive_on_prefixes() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    var filter = new FeesOnlyFilter(true);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("/FEES/invoice1");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 
@@ -218,11 +216,11 @@ class FeesOnlyFilterTest {
 
   @Test
   void fees_only_active_blocks_empty_uri() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    var filter = new FeesOnlyFilter(true);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    var request = new MockHttpServletRequest();
     request.setRequestURI("");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+    var response = new MockHttpServletResponse();
 
     filter.doFilterInternal(request, response, filterChain);
 

--- a/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
+++ b/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
@@ -2,6 +2,7 @@ package school.hei.haapi.unit;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import jakarta.servlet.FilterChain;
@@ -19,73 +20,207 @@ import school.hei.haapi.endpoint.rest.security.FeesOnlyFilter;
 @ExtendWith(MockitoExtension.class)
 class FeesOnlyFilterTest {
 
-  @Mock private FilterChain filterChain;
+    @Mock private FilterChain filterChain;
 
-  @Test
-  void fees_only_inactive_all_requests_pass() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(false);
+    @Test
+    void fees_only_inactive_all_requests_pass() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(false);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setRequestURI("/teachers");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/teachers");
+        MockHttpServletResponse response = new MockHttpServletResponse();
 
-    filter.doFilterInternal(request, response, filterChain);
+        filter.doFilterInternal(request, response, filterChain);
 
-    assertEquals(200, response.getStatus());
-    verify(filterChain).doFilter(request, response);
-  }
-
-  @Test
-  void fees_only_active_allows_configured_prefixes() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
-
-    List<String> allowedPrefixes =
-        List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
-
-    for (String prefix : allowedPrefixes) {
-      MockHttpServletRequest request = new MockHttpServletRequest();
-      request.setRequestURI(prefix);
-      MockHttpServletResponse response = new MockHttpServletResponse();
-
-      filter.doFilterInternal(request, response, filterChain);
-
-      assertEquals(
-          200, response.getStatus(), "URI " + prefix + " should be allowed in FEES_ONLY mode");
+        assertEquals(200, response.getStatus());
+        verify(filterChain).doFilter(request, response);
     }
-  }
 
-  @Test
-  void fees_only_active_blocks_other_uris() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    @Test
+    void fees_only_active_allows_configured_prefixes() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-    List<String> blockedUris =
-        List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
+        List<String> allowedPrefixes =
+                List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
 
-    for (String uri : blockedUris) {
-      MockHttpServletRequest request = new MockHttpServletRequest();
-      request.setRequestURI(uri);
-      MockHttpServletResponse response = new MockHttpServletResponse();
+        for (String prefix : allowedPrefixes) {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setRequestURI(prefix);
+            MockHttpServletResponse response = new MockHttpServletResponse();
 
-      filter.doFilterInternal(request, response, filterChain);
+            filter.doFilterInternal(request, response, filterChain);
 
-      assertEquals(SC_FORBIDDEN, response.getStatus(), "URI " + uri + " should be blocked");
-      assertEquals(
-          "{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}",
-          response.getContentAsString());
+            assertEquals(
+                    200, response.getStatus(), "URI " + prefix + " should be allowed in FEES_ONLY mode");
+        }
     }
-  }
 
-  @Test
-  void fees_only_active_allows_subpaths_of_allowed_prefixes() throws ServletException, IOException {
-    FeesOnlyFilter filter = new FeesOnlyFilter(true);
+    @Test
+    void fees_only_active_blocks_other_uris() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setRequestURI("/students/student1_id/fees/fee1_id/payments");
-    MockHttpServletResponse response = new MockHttpServletResponse();
+        List<String> blockedUris =
+                List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
 
-    filter.doFilterInternal(request, response, filterChain);
+        for (String uri : blockedUris) {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setRequestURI(uri);
+            MockHttpServletResponse response = new MockHttpServletResponse();
 
-    assertEquals(200, response.getStatus());
-    verify(filterChain).doFilter(request, response);
-  }
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertEquals(SC_FORBIDDEN, response.getStatus(), "URI " + uri + " should be blocked");
+            assertEquals(
+                    "{\"message\": \"This endpoint is disabled in FEES_ONLY mode\"}",
+                    response.getContentAsString());
+        }
+    }
+
+    @Test
+    void fees_only_active_allows_subpaths_of_allowed_prefixes() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/students/student1_id/fees/fee1_id/payments");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(200, response.getStatus());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void fees_only_inactive_allows_previously_blocked_uris() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+
+        List<String> uris =
+                List.of("/teachers", "/groups", "/events", "/courses", "/exams", "/unknown");
+
+        for (String uri : uris) {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setRequestURI(uri);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertEquals(200, response.getStatus(), "URI " + uri + " should pass when FEES_ONLY is inactive");
+        }
+    }
+
+    @Test
+    void fees_only_inactive_does_not_write_forbidden_body() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/exams");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals("", response.getContentAsString());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void fees_only_inactive_calls_filter_chain_for_every_request() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+
+        List<String> uris = List.of("/fees", "/students", "/teachers", "/anything/goes/here");
+
+        for (String uri : uris) {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setRequestURI(uri);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+        }
+    }
+
+    @Test
+    void fees_only_inactive_allows_root_and_empty_like_uris() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(false);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(200, response.getStatus());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void fees_only_active_does_not_call_filter_chain_when_blocked() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/teachers");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void fees_only_active_blocked_response_has_json_content_type() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/teachers");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals("application/json", response.getContentType());
+    }
+
+    @Test
+    void fees_only_active_blocks_uris_that_merely_start_with_allowed_prefix() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/feesnotreal");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(
+                SC_FORBIDDEN,
+                response.getStatus(),
+                "'/feesnotreal' should not be treated as a valid subpath of '/fees'");
+    }
+
+    @Test
+    void fees_only_active_is_case_sensitive_on_prefixes() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/FEES/invoice1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(
+                SC_FORBIDDEN,
+                response.getStatus(),
+                "startsWith() is case sensitive: '/FEES' does not match the '/fees' prefix");
+    }
+
+    @Test
+    void fees_only_active_blocks_empty_uri() throws ServletException, IOException {
+        FeesOnlyFilter filter = new FeesOnlyFilter(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(SC_FORBIDDEN, response.getStatus());
+    }
 }

--- a/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
+++ b/src/test/java/school/hei/haapi/unit/FeesOnlyFilterTest.java
@@ -40,14 +40,7 @@ class FeesOnlyFilterTest {
     FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
     List<String> allowedPrefixes =
-        List.of(
-            "/fees",
-            "/students",
-            "/whoami",
-            "/ping",
-            "/authentication",
-            "/health",
-            "/mpbs");
+        List.of("/fees", "/students", "/whoami", "/ping", "/authentication", "/health", "/mpbs");
 
     for (String prefix : allowedPrefixes) {
       MockHttpServletRequest request = new MockHttpServletRequest();
@@ -83,8 +76,7 @@ class FeesOnlyFilterTest {
   }
 
   @Test
-  void fees_only_active_allows_subpaths_of_allowed_prefixes()
-      throws ServletException, IOException {
+  void fees_only_active_allows_subpaths_of_allowed_prefixes() throws ServletException, IOException {
     FeesOnlyFilter filter = new FeesOnlyFilter(true);
 
     MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
Groupe 6:
Description
This PR introduces a fees-only mode filter to the API.

Configuration
The filter's behavior is dynamic and is enabled by defining the configuration directly in your .env file.

Changes
* feat: Added the fees-only mode filter.
* test: Added unit tests to validate the filter's behavior, including edge cases 
  (feesOnly = false, case sensitivity, prefix boundaries).
* docs: Documented the FEES_ONLY resource.
* fix: Corrected prefix matching to avoid false positives — a URI like "/feesnotreal" 
  was previously treated as an allowed subpath of "/fees".
* refactor: Removed manual constructor using System.getenv(); now relies solely on 
  Spring's @Value injection per review feedback.
